### PR TITLE
Fix how standards path is resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.4
 - Updated Dependencies
 - Fix an issue causing the content of files to be deleted by the Fixer
+- Add basic support for resolving standards files in a multi-workspace project
 ## 0.0.3
 - Fix some language in the DEVELOPMENT.md
 - Fix some debug information

--- a/src/resolvers/standards-path-resolver.ts
+++ b/src/resolvers/standards-path-resolver.ts
@@ -8,7 +8,7 @@
 import * as fs from 'fs';
 
 import { PathResolverBase } from './path-resolver-base';
-import { TextDocument } from 'vscode';
+import { TextDocument, workspace } from 'vscode';
 import { Settings } from '../settings';
 
 export class StandardsPathResolver extends PathResolverBase {
@@ -23,8 +23,13 @@ export class StandardsPathResolver extends PathResolverBase {
         }
 
         let resolvedPath: string | null = null;
-        let workspaceRoot = this.config.workspaceRoot + this.pathSeparator;
-        let localPath = this.document.uri.fsPath.replace(workspaceRoot, '');
+        const resource = this.document.uri;
+        const folder = workspace.getWorkspaceFolder(resource);
+        if (!folder) {
+            return '';
+        }
+        let workspaceRoot = folder.uri.fsPath + this.pathSeparator;
+        let localPath = resource.fsPath.replace(workspaceRoot, '');
         let paths = localPath.split(this.pathSeparator)
             .filter(path => path.includes('.php') !== true);
 


### PR DESCRIPTION
This will handle correctly finding standards configuration files in a multi-workspace project. Additional refactoring will be needed to fully support the multi-workspace resolution of phpcs and phpcbf.