### PR TITLE
Throw exception for empty document

### DIFF
--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -272,7 +272,7 @@ export class Fixer {
                     if (text.length > 0) {
                         resolve([new TextEdit(fullRange, text)]);
                     }
-                    resolve([]);
+                    throw new Error("PHPCBF returned an empty document");
                 })
                 .catch((err) => {
                     window.showErrorMessage(err);


### PR DESCRIPTION
If the phpcbf process returns an empty document with a length not greater than zero we will now just throw an exception.

This should make sure that #57 never happens.