### PR TITLE
Set logLevel in configuration before attempting to log info.

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,6 +19,9 @@ export class Configuration {
     constructor(private logger: Logger) {
         this.config = workspace.getConfiguration("phpsab");
         this.debug = this.config.get("debug", false);
+
+        let logLevel: LogLevel = this.debug ? 'INFO' : 'ERROR';
+        this.logger.setOutputLevel(logLevel);
     }
 
     /**
@@ -80,9 +83,6 @@ export class Configuration {
             snifferTypeDelay: this.config.get("snifferTypeDelay", 250),
             debug: this.debug,
         };
-
-        let logLevel: LogLevel = settings.debug ? 'INFO' : 'ERROR';
-        this.logger.setOutputLevel(logLevel);
         this.logger.logInfo('CONFIGURATION', settings);
         return settings;
     }


### PR DESCRIPTION
Necessary debugging logs do not display due to the logLevel being set too late.

For me, the logs: "The phpcs executable was not found for " + resource and "The phpcbf executable was not found for " + resource wouldn't display
