### PR TITLE
Fix Sniffer from exiting early based on the first folder's settings

### DIFF
--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -56,7 +56,7 @@ export class Sniffer {
         private logger: Logger
     ) {
         this.config = config;
-        if (config.resources[0].snifferEnable === false) {
+        if (config.resources.filter(folder => folder.snifferEnable === true).length === 0) {
             return;
         }
         workspace.onDidChangeConfiguration(


### PR DESCRIPTION
**Issue**
Sniffer doesn't run if the first folder in the workspace has snifferEnable set to false. In my case, if phpcs lives in the 2nd workspace folder, it won't run for the entire workspace. Likely related: https://github.com/valeryan/vscode-phpsab/issues/75

**Solution**
Allow Sniffer to run as long as one of the folders has snifferEnable set to true.