### PR TITLE
fix(fixer): restore the addition of the GitModified filter option

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,8 +42,8 @@ export const activate = async (context: ExtensionContext) => {
     languages.registerDocumentRangeFormattingEditProvider(
       { scheme: 'file', language: 'php' },
       {
-        provideDocumentRangeFormattingEdits: (document) => {
-          return registerFixerAsDocumentProvider(document);
+        provideDocumentRangeFormattingEdits: (document, range) => {
+          return registerFixerAsDocumentProvider(document, range);
         },
       },
     ),


### PR DESCRIPTION
Not sure if it was correct to remove the filter. I need to test if its correct to use git modified here or remove and cleanup document range.

The logic for git modified was added here: https://github.com/valeryan/vscode-phpsab/pull/54
This logic was removed here: https://github.com/valeryan/vscode-phpsab/pull/55/files#diff-8252e32d33853b0c73ac8a3449d744d96025b7aa6926201d9ae16c4a6d3c079bL113 

But did I remove it by mistake or for reason? The world may never know. 

![image](https://github.com/user-attachments/assets/802025ad-2642-4f54-bcab-58b9b0e0d74c)
