### PR TITLE
Wrap the --stdin-path argument in double quotes

### DIFF
--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -66,7 +66,7 @@ const getArgs = (
   if (standard !== '') {
     args.push('--standard=' + standard);
   }
-  args.push(`--stdin-path=${filePath}`);
+  args.push(`--stdin-path="${filePath}"`);
   args.push('-');
   args = args.concat(additionalArguments);
   return args;


### PR DESCRIPTION
Fixes an issue with spaces in file/directory paths

Closes #136