### PR TITLE
Revert "Escape filePath and args passed to the phpcs command (#145)"

### DIFF
--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -55,9 +55,9 @@ const getArgs = (
   let args = [];
   args.push('-q');
   if (standard !== '') {
-    args.push('--standard=' + standard);
+    args.push(`--standard="${standard}"`);
   }
-  args.push(`--stdin-path=${filePath}`);
+  args.push(`--stdin-path="${filePath}"`);
   args = args.concat(additionalArguments);
   args.push('-');
   return args;

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -54,6 +54,25 @@ const getArgs = (
 
   let args = [];
   args.push('-q');
+
+  /**
+   * Important Note as explained in PR #155:
+   *
+   * For the fixer to work properly, we don't add `shell: true` to spawn.sync's options,
+   * so spawn runs with the default of `shell: false`. This is important because when spawn runs on
+   * Windows with the default it automatically escapes the command and values, including
+   * surrounding them in double quotes (" ").
+   *
+   * So we don't need to add double quotes around the values for the `--standard` and `--stdin-path`
+   * options, otherwise the values will get double the amount of quotes and errors will occur.
+   *
+   * e.g. ["ERROR" - 10:33:56 PM] ERROR: the ""d:\Name\projects\my project\phpcs.xml"" coding
+   * standard is not installed. The installed coding standards are MySource, PEAR, PSR1, PSR2,
+   * PSR12, Squiz, Zend and JPSR12.
+   *
+   * The sniffer is different, it needs to be surrounded by double quotes.
+   */
+
   if (standard !== '') {
     args.push(`--standard=${standard}`);
   }

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -55,9 +55,9 @@ const getArgs = (
   let args = [];
   args.push('-q');
   if (standard !== '') {
-    args.push(`--standard="${standard}"`);
+    args.push(`--standard=${standard}`);
   }
-  args.push(`--stdin-path="${filePath}"`);
+  args.push(`--stdin-path=${filePath}`);
   args = args.concat(additionalArguments);
   args.push('-');
   return args;

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -59,8 +59,6 @@ const getArgs = (
 ) => {
   // Process linting paths.
   let filePath = document.fileName;
-  filePath = escapePath(filePath);
-  standard = escapePath(standard);
 
   let args = [];
   args.push('--report=json');
@@ -72,16 +70,6 @@ const getArgs = (
   args.push('-');
   args = args.concat(additionalArguments);
   return args;
-};
-
-/**
- * Escape spaces in the path string
- *
- * @param stringPath - The string to escape
- * @returns string
- */
-const escapePath = (stringPath: string) => {
-  return stringPath.replace(/ /g, '\\ ');
 };
 
 /**

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -64,7 +64,7 @@ const getArgs = (
   args.push('--report=json');
   args.push('-q');
   if (standard !== '') {
-    args.push('--standard=' + standard);
+    args.push(`--standard="${standard}"`);
   }
   args.push(`--stdin-path="${filePath}"`);
   args.push('-');

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -63,6 +63,21 @@ const getArgs = (
   let args = [];
   args.push('--report=json');
   args.push('-q');
+
+  /**
+   * Important Note as explained in PR #155:
+   *
+   * For the sniffer to work properly, we add `shell: true` to spawn's options.
+   * This is important because when spawn runs on Windows with `shell: true`, it won't automatically
+   * escape the command and values, instead it just passes it straight to the shell as is.
+   *
+   * So we need to add double quotes around the values for the `--standard` and `--stdin-path`
+   * options, otherwise when there's spaces in the values it will break the command and errors will
+   * occur (as documented in issues #136 and #144).
+   *
+   * The fixer is different, it doesn't need to be surrounded by double quotes.
+   */
+
   if (standard !== '') {
     args.push(`--standard="${standard}"`);
   }


### PR DESCRIPTION
This reverts commit 58b1febbef5aec408805c4a4f287c31c533e8570.

The code to escape spaces in filepaths doesn't work on Windows. It just thinks it's a directory...

![image](https://github.com/user-attachments/assets/c33f7796-1a7f-408f-99d6-2350148c13d2)

Instead this PR adds double quotes to both the filepath and standard, for both sniffer and fixer.