### PR TITLE
Fix php not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,12 @@
           "type": "boolean",
           "default": false,
           "description": "Write debug info to the console"
+        },
+        "phpsab.phpExecutablePath": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "(Optional) The path to the PHP executable."
         }
       }
     }

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -55,9 +55,9 @@ const getArgs = (
   let args = [];
   args.push('-q');
   if (standard !== '') {
-    args.push('--standard=' + standard);
+    args.push(`--standard="${standard}"`);
   }
-  args.push(`--stdin-path=${filePath}`);
+  args.push(`--stdin-path="${filePath}"`);
   args = args.concat(additionalArguments);
   args.push('-');
   return args;

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -55,9 +55,9 @@ const getArgs = (
   let args = [];
   args.push('-q');
   if (standard !== '') {
-    args.push(`--standard="${standard}"`);
+    args.push(`--standard=${standard}`);
   }
-  args.push(`--stdin-path="${filePath}"`);
+  args.push(`--stdin-path=${filePath}`);
   args = args.concat(additionalArguments);
   args.push('-');
   return args;

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -146,7 +146,7 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   const fixer = spawn.sync(resourceConf.executablePathCBF, lintArgs, options);
   const stdout = fixer.stdout.toString().trim();
 
-  let fixed = stdout + '\n';
+  let fixed = stdout;
 
   let errors: { [key: number]: string } = {
     3: 'FIXER: A general script execution error occurred.',
@@ -217,7 +217,7 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
     default:
       error = errors[fixer.status];
       if (fixed.length > 0) {
-        error += '\n' + fixed;
+        error += '\n' + fixed + '\n';
       }
       logger.error(fixed);
   }

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -6,4 +6,5 @@ export interface Settings {
   snifferMode: string;
   snifferTypeDelay: number;
   snifferShowSources: boolean;
+  phpExecutablePath: string;
 }

--- a/src/resolvers/path-resolver-utils.ts
+++ b/src/resolvers/path-resolver-utils.ts
@@ -9,5 +9,21 @@ export const getPlatformPathSeparator = (): string =>
 export const getEnvPathSeparator = (): string =>
   /^win/.test(process.platform) ? ';' : ':';
 
+/**
+ * Adds the PHP executable path to the Node process's environment path.
+ *
+ * @param phpExecutablePath The PHP executable path from extension settings.
+ */
+export const addPhpToEnvPath = (phpExecutablePath: string) => {
+  // If the path ends with /php.exe, remove it because we only need the directory path.
+  if (phpExecutablePath.endsWith('/php.exe')) {
+    phpExecutablePath = phpExecutablePath.replace('/php.exe', '');
+  }
+
+  if (!process.env.PATH.includes(phpExecutablePath)) {
+    process.env.PATH =
+      process.env.PATH + getEnvPathSeparator() + phpExecutablePath;
+  }
+};
 // Create passthrough methods for path, allows for easier replacement in test
 export const joinPaths = (...args: string[]): string => path.join(...args);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -141,6 +141,7 @@ export const loadSettings = async () => {
     snifferShowSources: config.get('snifferShowSources', false),
     snifferTypeDelay: config.get('snifferTypeDelay', 250),
     debug: config.get('debug', false),
+    phpExecutablePath: config.get('phpExecutablePath', ''),
   };
 
   logger.setDebugMode(settings.debug);

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -59,8 +59,6 @@ const getArgs = (
 ) => {
   // Process linting paths.
   let filePath = document.fileName;
-  filePath = escapePath(filePath);
-  standard = escapePath(standard);
 
   let args = [];
   args.push('--report=json');
@@ -72,16 +70,6 @@ const getArgs = (
   args.push('-');
   args = args.concat(additionalArguments);
   return args;
-};
-
-/**
- * Escape spaces in the path string
- *
- * @param stringPath - The string to escape
- * @returns string
- */
-const escapePath = (stringPath: string) => {
-  return stringPath.replace(/ /g, '\\ ');
 };
 
 /**

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -18,6 +18,7 @@ import {
 import { PHPCSMessageType, PHPCSReport } from './interfaces/phpcs-report';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
+import { addPhpToEnvPath } from './resolvers/path-resolver-utils';
 import { createStandardsPathResolver } from './resolvers/standards-path-resolver';
 import { loadSettings } from './settings';
 
@@ -120,6 +121,10 @@ const validate = async (document: TextDocument) => {
   const lintArgs = getArgs(document, standard, additionalArguments);
 
   let fileText = document.getText();
+
+  if (settings.phpExecutablePath != '') {
+    addPhpToEnvPath(settings.phpExecutablePath);
+  }
 
   const options = {
     cwd:

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -64,7 +64,7 @@ const getArgs = (
   args.push('--report=json');
   args.push('-q');
   if (standard !== '') {
-    args.push('--standard=' + standard);
+    args.push(`--standard="${standard}"`);
   }
   args.push(`--stdin-path="${filePath}"`);
   args.push('-');


### PR DESCRIPTION
Fixes #57 and #156 by using the open PR's #142 and #155. 

Adds new `phpExecutablePath` setting to specify the path to PHP executable, which injects the php path into Node's process environment path before running the sniffer and fixer, and adds an error message to show to the user if the fixer returns with an stderr as "php is not recognized".