### PR TITLE
fix: empty document error when no changes needed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,8 +39,10 @@ export const activate = async (context: ExtensionContext) => {
     languages.registerDocumentRangeFormattingEditProvider(
       { scheme: 'file', language: 'php' },
       {
-        provideDocumentRangeFormattingEdits: (document, range) => {
-          logger.info(`DEBUG: Starting format with document: ${document.fileName}`);
+        provideDocumentRangeFormattingEdits: async (document, range) => {
+          logger.info(
+            `DEBUG: Starting format with document: ${document.fileName}`,
+          );
           logger.info(`DEBUG: Range: ${JSON.stringify(range)}`);
           try {
             return await registerFixerAsDocumentProvider(document, range);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,14 @@ export const activate = async (context: ExtensionContext) => {
       { scheme: 'file', language: 'php' },
       {
         provideDocumentRangeFormattingEdits: (document, range) => {
-          return registerFixerAsDocumentProvider(document, range);
+          logger.info(`DEBUG: Starting format with document: ${document.fileName}`);
+          logger.info(`DEBUG: Range: ${JSON.stringify(range)}`);
+          try {
+            return registerFixerAsDocumentProvider(document, range);
+          } catch (error) {
+            logger.error(`DEBUG: Error in provider: ${error}`);
+            throw error;
+          }
         },
       },
     ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export const activate = async (context: ExtensionContext) => {
           logger.info(`DEBUG: Starting format with document: ${document.fileName}`);
           logger.info(`DEBUG: Range: ${JSON.stringify(range)}`);
           try {
-            return registerFixerAsDocumentProvider(document, range);
+            return await registerFixerAsDocumentProvider(document, range);
           } catch (error) {
             logger.error(`DEBUG: Error in provider: ${error}`);
             throw error;

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -259,13 +259,14 @@ export const registerFixerAsDocumentProvider = (
     format(document, isFullDocument)
       .then((text) => {
         if (text.length > 0) {
-          resolve([new TextEdit(fullRange, text)]);
+          return resolve([new TextEdit(fullRange, text)]);
+        } else {
+          throw new Error('PHPCBF returned an empty document');
         }
-        throw new Error('PHPCBF returned an empty document');
       })
       .catch((err) => {
         window.showErrorMessage(err);
-        reject();
+        return reject(err);
       });
   });
 };


### PR DESCRIPTION
Fixes the "PHPCBF returned an empty document" error that occurs when a file needs no formatting changes.

**Bug:**

- Formatter throws error when PHPCBF returns unchanged document text
- Error caused by incorrect promise chain logic throwing error unnecessarily

**Changes:**

- Add proper error handling in provideDocumentRangeFormattingEdits
- Fix promise logic in registerFixerAsDocumentProvider
- Only throw empty document error when text length is 0

**Testing:**

1. Open PHP file that passes formatting standards
2. Try to format document
3. Verify formatter completes without error
