### PR TITLE
Feat: Display icons on problems to determine their auto fixability

### DIFF
--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -192,7 +192,7 @@ const validate = async (document: TextDocument) => {
               }
               output += `\nAuto-fixable: ${fixable ? '✔️' : '❌'}`;
               const diagnostic = new Diagnostic(range, output, severity);
-              diagnostic.source = 'phpcs';
+              diagnostic.source = '\nphpcs';
               diagnostics.push(diagnostic);
             },
           );


### PR DESCRIPTION
This PR enhances the message of PHPCS issues outputted to the Problems tab. Each issue will now indicate whether it's auto fixable or not.

#### Background:
In the Problems tab, the 100s of problems can be overwhelming to read through if you're debugging or curious at what issues PHPCS has reported. It can be annoying going through each one, and not being able to tell what needs attention for manual fixing and which can be auto fixed. It would be very useful to display an icon on the problem to let the user know what is auto fixable.

#### Implementation:

Because we're already setting a boolean to `fixable` per issue in the `PHPCSMessage` interface, we can just use this property to determine the icon. So this is now a really simple enhancement to just append the new message with the icon to the `output` variable.

##### Caveat:

For the icons to work, we must use copy/paste-able character icons: ✔️❌;  since VScode's `Diagnostic` API doesn't allow the usage of codicons.

#### Result:

The issues now display whether they can be auto fixed, which makes them more readable and easier to spot problematic issues.

Problems tab:
<img width="749" height="153" alt="image" src="https://github.com/user-attachments/assets/0218ff59-0c05-4fb1-bca6-fe76be580723" />

Editor on-hover Intellisense:
<img width="791" height="209" alt="image" src="https://github.com/user-attachments/assets/316856b2-673c-41a4-a8c3-58329accf685" />

