### PR TITLE
fix: improve the workspace not found error.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,13 @@
  * Copyright (c) 2019 Samuel Hilson. All rights reserved.
  * Licensed under the MIT License. See License.md in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import { commands, ExtensionContext, extensions, languages } from 'vscode';
+import {
+  commands,
+  ExtensionContext,
+  extensions,
+  languages,
+  workspace,
+} from 'vscode';
 import { activateFixer, registerFixerAsDocumentProvider } from './fixer';
 import { disposeLogger, logger } from './logger';
 import { loadSettings } from './settings';
@@ -21,6 +27,13 @@ export const activate = async (context: ExtensionContext) => {
   // Always output extension information to channel on activate
   logger.log(`Extension ID: ${extensionId}.`);
   logger.log(`Extension Version: ${extensionVersion}.`);
+
+  if (!workspace.workspaceFolders) {
+    const errorMsg =
+      'Workspace folder not found. Please open a folder or workspace to use PHP Sniffer & Beautifier';
+    logger.error(errorMsg);
+    throw new Error(errorMsg);
+  }
 
   const settings = await loadSettings();
   activateFixer(context.subscriptions, settings);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -96,9 +96,6 @@ const validate = async (
 };
 
 export const loadSettings = async () => {
-  if (!workspace.workspaceFolders) {
-    throw new Error('Unable to load configuration.');
-  }
   const resourcesSettings: Array<ResourceSettings> = [];
 
   // Handle per Workspace settings


### PR DESCRIPTION
As per discussion in #123, the "Unable to load configuration." error is not user friendly and doesn't explain why configuration wasn't loaded.

Fixed by changing the error completely to "Workspace folder not found. Please open a folder or workspace to use PHP Sniffer & Beautifier".

- Removed the no workspace folder check from the `loadSettings` function since it's checking if there's a workspace folder open, which has nothing to do with settings.

- Added the workspace folder check to the `activate` function so that the extension doesn't run things deeper than it needs to.

- Added the new improved error message, also enabled logging this error to the Output channel as well for added debugging of future issues.