### PR TITLE
Support single file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This extension supports the [latest stable version of PHPCS 3.x](https://github.
 My focus has shifted away from PHP to .NET development, I'm currently unable to dedicate much time to maintaining this project. However, the extension is fully operational in its current state. If you're interested in contributing as a co-maintainer to address any outstanding issues, please feel free to get in touch with me.
 
 ### Active Maintainers
+
 In Sept of 2025 [yCodeTech](https://github.com/yCodeTech) was added as a maintainer.
 
 In June 2023 [jonathanbossenger](https://github.com/jonathanbossenger) reached out to me and offered to help with maintaining the extension. I have added him as a contributor and he will be monitoring new issues and helping me review PRs. I will still be around to help out if needed.
@@ -43,6 +44,21 @@ You can also use this formatter with Format on Save enabled. Format on save has 
 ## Multi-Root Workspace Support
 
 This extension now fully supports Multi-Root Workspaces. The extension previously used the first root folder in your workspace to configure and run both phpcs and phpcbf. The new system allows each workspace to be configured and run independently with respect to the root folder of the open file being sniffed. This means you can have phpcs functionality in one folder and have it disabled in another within a workspace.
+
+## Single File Mode Support
+
+This extension now supports formatting single files without needing a workspace folder open (single file mode). Both phpcs and phpcbf will work in this mode.
+
+When in single file mode:
+
+-   The global user settings are used instead of workspace settings.
+-   The `autoRulesetSearch` setting is ignored, and will essentially act as if it was set to `false` (and just return the file path as set in `standard`).
+
+A global composer setup is required:
+
+-   The `executablePathCS` and `executablePathCBF` settings **must** be set to the full absolute path of phpcs and phpcbf respectively, _OR_ set them to empty strings to allow the extension to automatically find the global composer installation and resolve the paths to the globally installed phpcs/phpcbf.
+
+-   If the `phpsab.standard` setting is used for a ruleset file then it **must** be the full absolute path.
 
 ## Linter Installation
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "lint": "eslint src --ext ts",
     "pretest": "npm run compile && npm run lint",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "ts-watch": "tsc -watch -p ./"
   },
   "dependencies": {
     "cross-spawn": "^7.0.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,25 +2,25 @@
  * Copyright (c) 2019 Samuel Hilson. All rights reserved.
  * Licensed under the MIT License. See License.md in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import { commands, ExtensionContext, extensions, languages } from 'vscode';
+import { commands, ExtensionContext, languages } from 'vscode';
 import { activateFixer, registerFixerAsDocumentProvider } from './fixer';
 import { disposeLogger, logger } from './logger';
 import { loadSettings } from './settings';
 import { activateSniffer, disposeSniffer } from './sniffer';
+import { getExtensionInfo, setExtensionInfo } from './utils';
 
 /**
  * Activate Extension
  * @param context
  */
 export const activate = async (context: ExtensionContext) => {
-  // Get extension unique identifier from context
-  const extensionId = context.extension.id;
-  const extensionVersion =
-    extensions.getExtension(extensionId)?.packageJSON.version;
+  setExtensionInfo(context);
+  const { id, displayName, version } = getExtensionInfo();
 
   // Always output extension information to channel on activate
-  logger.log(`Extension ID: ${extensionId}.`);
-  logger.log(`Extension Version: ${extensionVersion}.`);
+  logger.log(`Extension ID: ${id}.`);
+  logger.log(`Extension Display Name: ${displayName}.`);
+  logger.log(`Extension Version: ${version}.`);
 
   const settings = await loadSettings();
   activateFixer(context.subscriptions, settings);

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -109,10 +109,8 @@ const isFullDocumentRange = (range: Range, document: TextDocument) =>
 const format = async (document: TextDocument, fullDocument: boolean) => {
   const settings = await getSettings();
   const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
-  if (!workspaceFolder) {
-    return '';
-  }
-  const resourceConf = settings.resources[workspaceFolder.index];
+
+  const resourceConf = settings.resources[workspaceFolder?.index ?? 0];
   if (document.languageId !== 'php') {
     return '';
   }

--- a/src/interfaces/extensionInfo.ts
+++ b/src/interfaces/extensionInfo.ts
@@ -1,0 +1,5 @@
+export interface ExtensionInfo {
+  id: string;
+  displayName: string;
+  version: string;
+}

--- a/src/interfaces/resource-settings.ts
+++ b/src/interfaces/resource-settings.ts
@@ -1,5 +1,5 @@
 export interface ResourceSettings {
-  workspaceRoot: string;
+  workspaceRoot: string | null;
   fixerEnable: boolean;
   fixerArguments: string[];
   snifferEnable: boolean;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import { OutputChannel, window } from 'vscode';
+import { getExtensionInfo } from './utils';
 
 let outputChannel: OutputChannel;
 
@@ -17,7 +18,9 @@ export const setupOutputChannel = (channelOverride?: OutputChannel): void => {
     outputChannel = channelOverride;
     return;
   }
-  outputChannel = window.createOutputChannel('PHP Sniffer & Beautifier');
+  const { displayName } = getExtensionInfo();
+
+  outputChannel = window.createOutputChannel(displayName);
 };
 
 /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -66,6 +66,14 @@ export const log = (message: string): void => {
 };
 
 /**
+ * Send a basic warning log to output channel
+ * @param message string to be logged
+ */
+export const warn = (message: string): void => {
+  logMessage('WARNING', message);
+};
+
+/**
  * Send a error message and a stack trace if available
  * @param message string to be logged
  * @param error Error an Error object
@@ -150,6 +158,7 @@ export const logger = {
   log,
   info,
   debug,
+  warn,
   error,
   startTimer,
   endTimer,

--- a/src/resolvers/standards-path-resolver.ts
+++ b/src/resolvers/standards-path-resolver.ts
@@ -3,6 +3,7 @@ import { TextDocument, workspace } from 'vscode';
 import { PathResolver } from '../interfaces/path-resolver';
 import { ResourceSettings } from '../interfaces/resource-settings';
 import { logger } from '../logger';
+import { isSingleFileMode } from '../settings';
 import {
   getPlatformExtension,
   getPlatformPathSeparator,
@@ -19,7 +20,7 @@ export const createStandardsPathResolver = (
     pathSeparator,
     resolve: async () => {
       let configured = config.standard ?? '';
-      if (config.autoRulesetSearch === false) {
+      if (config.autoRulesetSearch === false || isSingleFileMode()) {
         return configured;
       }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -119,7 +119,7 @@ export const loadSettings = async () => {
     let settings = await getSettings(globalConfig);
     settings = await validate(settings, 'Single File Mode');
 
-    resourcesSettings.splice(0, 0, settings);
+    resourcesSettings.unshift(settings);
   } else {
     // Handle per Workspace settings
 
@@ -137,7 +137,7 @@ export const loadSettings = async () => {
 
       settings = await validate(settings, workspaceFolders[index].name);
 
-      resourcesSettings.splice(index, 0, settings);
+      resourcesSettings.push(settings);
     }
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ import { ResourceSettings } from './interfaces/resource-settings';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
 import { createPathResolver } from './resolvers/path-resolver';
+import { getExtensionInfo } from './utils';
 
 /**
  * Check if the editor is in single file mode.
@@ -110,11 +111,12 @@ export const loadSettings = async () => {
 
   // Handle case where no workspace folders exist (single file mode).
   if (isSingleFileMode()) {
-    const warningMsg =
-      'No workspace folder open. PHP Sniffer & Beautifier will run with limited functionality. Please open a folder or workspace.';
+    const { displayName } = getExtensionInfo();
+
+    const warningMsg = `No workspace folder open. ${displayName} will run with limited functionality. Please open a folder or workspace.`;
 
     logger.warn(warningMsg);
-    window.showWarningMessage(warningMsg);
+    window.showWarningMessage(warningMsg, 'OK');
 
     let settings = await getSettings(globalConfig);
     settings = await validate(settings, 'Single File Mode');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -119,7 +119,7 @@ export const loadSettings = async () => {
     let settings = await getSettings(globalConfig);
     settings = await validate(settings, 'Single File Mode');
 
-    resourcesSettings.unshift(settings);
+    resourcesSettings.push(settings);
   } else {
     // Handle per Workspace settings
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,7 +111,7 @@ export const loadSettings = async () => {
   // Handle case where no workspace folders exist (single file mode).
   if (isSingleFileMode()) {
     const warningMsg =
-      'No workspace folder open. PHP Sniffer & Beautifier requires a workspace to function properly. Activating single file mode.';
+      'No workspace folder open. PHP Sniffer & Beautifier will run with limited functionality. Please open a folder or workspace.';
 
     logger.warn(warningMsg);
     window.showWarningMessage(warningMsg);

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -94,11 +94,9 @@ const getArgs = (
  */
 const validate = async (document: TextDocument) => {
   const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
-  if (!workspaceFolder) {
-    return;
-  }
+
   const settings = await getSettings();
-  const resourceConf = settings.resources[workspaceFolder.index];
+  const resourceConf = settings.resources[workspaceFolder?.index ?? 0];
   if (document.languageId !== 'php' || resourceConf.snifferEnable === false) {
     return;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+import { ExtensionContext, extensions } from 'vscode';
+import { ExtensionInfo } from './interfaces/extensionInfo';
+
+const extensionInfo: ExtensionInfo = {} as ExtensionInfo;
+
+export const setExtensionInfo = (context: ExtensionContext) => {
+  // Get extension unique identifier from context
+  const id = context.extension.id;
+  const packageJSON = extensions.getExtension(id)?.packageJSON;
+
+  extensionInfo.id = id;
+  extensionInfo.displayName = packageJSON?.displayName;
+  extensionInfo.version = packageJSON?.version;
+};
+
+export const getExtensionInfo = (): ExtensionInfo => {
+  return extensionInfo;
+};


### PR DESCRIPTION
Fixes #123.

---

While trying to improve the workspace not found error (`Unable to load configuration.`) in #169, Copilot (in my local repo) suggested to avoid failing the extension entirely when there's a workspace is not available because it's poor UX:

> No, I don't think you should throw an error here. This approach is too aggressive for a VS Code extension and will create a poor user experience.
>
>Here's why throwing is problematic:
>
>1. Extension fails to activate entirely - Users lose all functionality
>2. No graceful degradation - Extension could still provide some utility
>3. Poor UX - VS Code shows cryptic error messages for failed extension activation
>4. Unnecessary restriction - Users might want to configure the extension before opening a workspace

It suggested to show a warning instead of throwing an error and continue with default settings.

---
This PR is a complete fix to support single file mode (no workspace open).

When in single file mode:

- The global user settings are used instead of workspace settings.
- The `autoRulesetSearch` setting is ignored, and will essentially act as if it was set to `false`.

A global composer setup is required:

- Users **must** set the `executablePathCS` and `executablePathCBF` settings to the full absolute path of phpcs and phpcbf respectively, or set them to empty strings to allow the extension to automatically find the global composer installation and resolve the paths to the globally installed phpcs/phpcbf.

- If users are setting the `phpsab.standard` setting to a ruleset file then they **must** use the full absolute path.