### PR TITLE
Fix Typings

### DIFF
--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -102,9 +102,10 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
       document,
       resourceConf,
     ).resolve();
-  } catch (error: any) {
-    window.showErrorMessage(error.message, 'OK');
-    logger.error(error.message);
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    window.showErrorMessage(errorMessage, 'OK');
+    logger.error(errorMessage);
 
     return '';
   }

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -10,6 +10,7 @@ import {
   window,
   workspace,
 } from 'vscode';
+import { OriginalCommand } from './interfaces/common';
 import { ConsoleError } from './interfaces/console-error';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
@@ -145,7 +146,7 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   const stderr = fixer.stderr.toString();
 
   // Set the original command information (not parsed) for Windows ENOENT error handling
-  const originalCommand = {
+  const originalCommand: OriginalCommand = {
     commandPath: CBFExecutable,
     args: lintArgs,
   };

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents the original executable command data before argument parsing/quoting.
+ *
+ * This is used by Windows ENOENT handling to report actionable errors
+ * with the original command path and arguments.
+ */
+export interface OriginalCommand {
+  /** Absolute or configured path to the executable command. */
+  commandPath: string;
+
+  /** Raw argument array passed to the executable. */
+  args: string[];
+}

--- a/src/interfaces/phpcs-report.ts
+++ b/src/interfaces/phpcs-report.ts
@@ -15,7 +15,7 @@ export interface PHPCSMessage {
 
 export interface PHPCSCounts {
   errors: number;
-  warning: number;
+  warnings: number;
   fixable?: number;
 }
 

--- a/src/interfaces/phpcs-report.ts
+++ b/src/interfaces/phpcs-report.ts
@@ -1,4 +1,4 @@
-export const enum PHPCSMessageType {
+export enum PHPCSMessageType {
   ERROR = 'ERROR',
   WARNING = 'WARNING',
 }

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -1,9 +1,11 @@
 import { ResourceSettings } from './resource-settings';
 
+export type SnifferMode = 'onSave' | 'onType';
+
 export interface Settings {
   resources: ResourceSettings[];
   debug: boolean;
-  snifferMode: string;
+  snifferMode: SnifferMode;
   snifferTypeDelay: number;
   snifferShowSources: boolean;
   snifferShowFixabilityIcons: boolean;

--- a/src/resolvers/path-resolver-utils.ts
+++ b/src/resolvers/path-resolver-utils.ts
@@ -3,14 +3,34 @@ import { logger } from '../logger';
 
 /**
  * Is the current platform Windows?
+ *
  * @returns boolean
  */
 export const isWin = (): boolean => /^win/.test(process.platform);
 
+/**
+ * Get the executable script extension for the current platform.
+ * Windows executable scripts typically have a '.bat' extension,
+ * while POSIX systems have no extension.
+ *
+ * @returns The executable script extension for the current platform.
+ */
 export const getPlatformExtension = (): string => (isWin() ? '.bat' : '');
 
+/**
+ * Get the appropriate path separator for the current platform.
+ * Windows uses '\' while POSIX systems use '/'.
+ *
+ * @returns The path separator for the current platform.
+ */
 export const getPlatformPathSeparator = (): string => (isWin() ? '\\' : '/');
 
+/**
+ * Get the appropriate PATH separator for the current platform to use when modifying
+ * the PATH environment variable. Windows uses ';' while POSIX systems use ':'.
+ *
+ * @returns The PATH separator for the current platform.
+ */
 export const getEnvPathSeparator = (): string => (isWin() ? ';' : ':');
 
 /**
@@ -32,7 +52,13 @@ export const addPhpToEnvPath = (phpExecutablePath: string) => {
     );
   }
 };
-// Create passthrough methods for path, allows for easier replacement in test
+
+/**
+ * Join multiple path segments into a single path string, normalizing separators for the current OS.
+ *
+ * @param args The path segments to join.
+ * @returns The joined path string.
+ */
 export const joinPaths = (...args: string[]): string => path.join(...args);
 
 /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Uri, WorkspaceConfiguration, window, workspace } from 'vscode';
 import { ResourceSettings } from './interfaces/resource-settings';
-import { Settings } from './interfaces/settings';
+import { Settings, SnifferMode } from './interfaces/settings';
 import { logger } from './logger';
 import { createPathResolver } from './resolvers/path-resolver';
 import {
@@ -211,14 +211,14 @@ export const loadSettings = async () => {
   // update settings from config
   let settings: Settings = {
     resources: resourcesSettings,
-    snifferMode: globalConfig.get('snifferMode', 'onSave'),
-    snifferShowSources: globalConfig.get('snifferShowSources', false),
-    snifferShowFixabilityIcons: globalConfig.get(
+    snifferMode: globalConfig.get<SnifferMode>('snifferMode', 'onSave'),
+    snifferShowSources: globalConfig.get<boolean>('snifferShowSources', false),
+    snifferShowFixabilityIcons: globalConfig.get<boolean>(
       'snifferShowFixabilityIcons',
       true,
     ),
-    snifferTypeDelay: globalConfig.get('snifferTypeDelay', 250),
-    debug: globalConfig.get('debug', false),
+    snifferTypeDelay: globalConfig.get<number>('snifferTypeDelay', 250),
+    debug: globalConfig.get<boolean>('debug', false),
     phpExecutablePath: await resolvePhpExecutablePath(globalConfig, PHPconfig),
   };
 
@@ -245,23 +245,23 @@ const getSettings = async (
   rootPath: string | null = null,
 ) => {
   let settings: ResourceSettings = {
-    fixerEnable: config.get('fixerEnable', true),
-    fixerArguments: config.get('fixerArguments', []),
+    fixerEnable: config.get<boolean>('fixerEnable', true),
+    fixerArguments: config.get<string[]>('fixerArguments', []),
     workspaceRoot: rootPath,
-    executablePathCBF: config.get('executablePathCBF', ''),
-    executablePathCS: config.get('executablePathCS', ''),
-    composerJsonPath: config.get('composerJsonPath', 'composer.json'),
-    standard: config.get('standard', ''),
-    autoRulesetSearch: config.get('autoRulesetSearch', true),
-    allowedAutoRulesets: config.get('allowedAutoRulesets', [
+    executablePathCBF: config.get<string>('executablePathCBF', ''),
+    executablePathCS: config.get<string>('executablePathCS', ''),
+    composerJsonPath: config.get<string>('composerJsonPath', 'composer.json'),
+    standard: config.get<string | null>('standard', ''),
+    autoRulesetSearch: config.get<boolean>('autoRulesetSearch', true),
+    allowedAutoRulesets: config.get<string[]>('allowedAutoRulesets', [
       '.phpcs.xml',
       'phpcs.xml',
       'phpcs.dist.xml',
       'ruleset.xml',
     ]),
-    snifferEnable: config.get('snifferEnable', true),
-    snifferArguments: config.get('snifferArguments', []),
-    excludeGlobs: config.get('excludeGlobs', [
+    snifferEnable: config.get<boolean>('snifferEnable', true),
+    snifferArguments: config.get<string[]>('snifferArguments', []),
+    excludeGlobs: config.get<string[]>('excludeGlobs', [
       '**/vendor/**',
       '**/node_modules/**',
     ]),

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -95,9 +95,10 @@ const validate = async (document: TextDocument) => {
       document,
       resourceConf,
     ).resolve();
-  } catch (error: any) {
-    window.showErrorMessage(error.message, 'OK');
-    logger.error(error.message);
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    window.showErrorMessage(errorMessage, 'OK');
+    logger.error(errorMessage);
 
     return;
   }

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -18,7 +18,7 @@ import {
 import { OriginalCommand } from './interfaces/common';
 import { ConsoleError } from './interfaces/console-error';
 import { PHPCSMessageType, PHPCSReport } from './interfaces/phpcs-report';
-import { Settings } from './interfaces/settings';
+import { Settings, SnifferMode } from './interfaces/settings';
 import { logger } from './logger';
 import { createStandardsPathResolver } from './resolvers/standards-path-resolver';
 import { loadSettings } from './settings';
@@ -33,11 +33,6 @@ import {
   parseArgs,
   shouldProcess,
 } from './utils/helpers';
-
-const enum runConfig {
-  save = 'onSave',
-  type = 'onType',
-}
 
 let settingsCache: Settings;
 const diagnosticCollection: DiagnosticCollection =
@@ -291,10 +286,10 @@ const setValidatorListener = async (): Promise<void> => {
     validatorListener.dispose();
   }
   const settings = await getSettings();
-  const run: runConfig = settings.snifferMode as runConfig;
+  const run: SnifferMode = settings.snifferMode;
   const delay: number = settings.snifferTypeDelay;
 
-  if (run === (runConfig.type as string)) {
+  if (run === 'onType') {
     const validator = debounce(
       ({ document }: TextDocumentChangeEvent): void => {
         validate(document);

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -15,6 +15,7 @@ import {
   window,
   workspace,
 } from 'vscode';
+import { OriginalCommand } from './interfaces/common';
 import { ConsoleError } from './interfaces/console-error';
 import { PHPCSMessageType, PHPCSReport } from './interfaces/phpcs-report';
 import { Settings } from './interfaces/settings';
@@ -132,7 +133,7 @@ const validate = async (document: TextDocument) => {
   const sniffer = spawn(command, options);
 
   // Set the original command information (not parsed) for Windows ENOENT error handling
-  const originalCommand = {
+  const originalCommand: OriginalCommand = {
     commandPath: CSExecutable,
     args: lintArgs,
   };

--- a/src/utils/error-handling/windows-enoent-error.ts
+++ b/src/utils/error-handling/windows-enoent-error.ts
@@ -24,7 +24,7 @@ import { isWin } from '../../resolvers/path-resolver-utils';
 /**
  * Add ENOENT error handling for Windows spawned processes using spawn or spawnSync.
  * @param {ChildProcess| SpawnSyncReturns<string | Buffer>} cp The ChildProcess instance or SpawnSyncReturns object
- * @param {any} originalCommand The original command information
+ * @param {OriginalCommand} originalCommand The original command information
  * @returns {Error | null | void} For spawnSync returns the `Error` object if ENOENT detected, `null` otherwise. For spawn and non-Windows systems returns `void`.
  */
 export function addWindowsEnoentError(
@@ -81,7 +81,7 @@ function hookIntoEmit(cp: ChildProcess, originalCommand: OriginalCommand) {
 /**
  * Verify if the error is an ENOENT error.
  * @param {number | null} status Exit status code
- * @param {any} originalCommand The original command information
+ * @param {OriginalCommand} originalCommand The original command information
  * @param {'spawn' | 'spawnSync'} syscall The syscall type, either `'spawn'` or `'spawnSync'`
  * @returns {Error | null} The ENOENT error or null
  */
@@ -106,7 +106,7 @@ function verifyEnoentError(
 
 /**
  * Create the ENOENT error for the specified command.
- * @param {any} originalCommand The original command information
+ * @param {OriginalCommand} originalCommand The original command information
  * @param {'spawn' | 'spawnSync'} syscall The syscall type, either `'spawn'` or `'spawnSync'`
  * @returns {Error} The ENOENT error
  */

--- a/src/utils/error-handling/windows-enoent-error.ts
+++ b/src/utils/error-handling/windows-enoent-error.ts
@@ -53,7 +53,7 @@ export function addWindowsEnoentError(
 /**
  * Hook into the `emit` method of the spawn ChildProcess instance to handle ENOENT errors.
  * @param {ChildProcess} cp The ChildProcess instance
- * @param {any} originalCommand The original command information
+ * @param {OriginalCommand} originalCommand The original command information
  */
 function hookIntoEmit(cp: ChildProcess, originalCommand: OriginalCommand) {
   // Store original emit method

--- a/src/utils/error-handling/windows-enoent-error.ts
+++ b/src/utils/error-handling/windows-enoent-error.ts
@@ -17,6 +17,7 @@
 
 import { ChildProcess, SpawnSyncReturns } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { OriginalCommand } from '../../interfaces/common';
 import { logger } from '../../logger';
 import { isWin } from '../../resolvers/path-resolver-utils';
 
@@ -28,7 +29,7 @@ import { isWin } from '../../resolvers/path-resolver-utils';
  */
 export function addWindowsEnoentError(
   cp: ChildProcess | SpawnSyncReturns<string | Buffer>,
-  originalCommand: any,
+  originalCommand: OriginalCommand,
   syscall: 'spawn' | 'spawnSync',
 ): Error | null | void {
   // If not on Windows, don't do anything
@@ -54,7 +55,7 @@ export function addWindowsEnoentError(
  * @param {ChildProcess} cp The ChildProcess instance
  * @param {any} originalCommand The original command information
  */
-function hookIntoEmit(cp: ChildProcess, originalCommand: any) {
+function hookIntoEmit(cp: ChildProcess, originalCommand: OriginalCommand) {
   // Store original emit method
   const originalEmit = cp.emit.bind(cp);
 
@@ -86,7 +87,7 @@ function hookIntoEmit(cp: ChildProcess, originalCommand: any) {
  */
 function verifyEnoentError(
   status: number | null,
-  originalCommand: any,
+  originalCommand: OriginalCommand,
   syscall: 'spawn' | 'spawnSync',
 ) {
   // If the exit code is `1` AND no file was found (the command) OR
@@ -110,7 +111,7 @@ function verifyEnoentError(
  * @returns {Error} The ENOENT error
  */
 function createEnoentError(
-  originalCommand: any,
+  originalCommand: OriginalCommand,
   syscall: 'spawn' | 'spawnSync',
 ) {
   return Object.assign(

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -69,10 +69,11 @@ export const getArgs = (
   args.push(`--stdin-path=${filePath}`);
 
   // Validate additional arguments.
-  additionalArguments = validateAdditionalArguments(additionalArguments);
+  const validatedAdditionalArguments =
+    validateAdditionalArguments(additionalArguments);
 
   // Append any additional arguments.
-  args = args.concat(additionalArguments);
+  args = args.concat(validatedAdditionalArguments);
 
   // Indicate we will be passing the file contents via stdin.
   // This must be the last argument.
@@ -163,7 +164,7 @@ const validateAdditionalArguments = (
   }
 
   // Return the filtered array or an empty array.
-  return filteredArguments ?? [];
+  return filteredArguments;
 };
 
 /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -28,8 +28,8 @@ export const setExtensionInfo = (context: ExtensionContext) => {
   const packageJSON = extensions.getExtension(id)?.packageJSON;
 
   extensionInfo.id = id;
-  extensionInfo.displayName = packageJSON?.displayName;
-  extensionInfo.version = packageJSON?.version;
+  extensionInfo.displayName = String(packageJSON?.displayName ?? id);
+  extensionInfo.version = String(packageJSON?.version ?? 'unknown');
 };
 
 export const getExtensionInfo = (): ExtensionInfo => {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -16,7 +16,11 @@ import { ResourceSettings } from '../interfaces/resource-settings';
 import { logger } from '../logger';
 import { isWin } from '../resolvers/path-resolver-utils';
 
-const extensionInfo: ExtensionInfo = {} as ExtensionInfo;
+const extensionInfo: ExtensionInfo = {
+  id: '',
+  displayName: '',
+  version: '',
+};
 
 export const setExtensionInfo = (context: ExtensionContext) => {
   // Get extension unique identifier from context
@@ -37,7 +41,7 @@ export const getExtensionInfo = (): ExtensionInfo => {
  * @param {string} filePath The file path to be linted or fixed. (Note: The path is obtained via vscode's API, so it's already normalized.)
  * @param {string} standard The coding standard to use.
  * @param {string[]} additionalArguments Any additional arguments to pass to the executable.
- * @param {string} toolType The type of tool being executed (e.g., 'sniffer', 'fixer').
+ * @param {'sniffer' | 'fixer'} toolType The type of tool being executed (e.g., 'sniffer', 'fixer').
  * @returns {string[]} The array of arguments to pass to the sniffer or fixer executable.
  */
 export const getArgs = (
@@ -46,7 +50,7 @@ export const getArgs = (
   additionalArguments: string[],
   toolType: 'sniffer' | 'fixer',
 ): string[] => {
-  let args = [];
+  let args: string[] = [];
 
   // If sniffer, we need to add the JSON report argument.
   if (toolType === 'sniffer') {
@@ -347,13 +351,13 @@ export const getEOL = (): string => {
  * Determines if a document should be processed.
  *
  * @param document - The document to check.
- * @param {string} toolType The type of tool being executed (e.g., 'sniffer', 'fixer').
+ * @param {'sniffer' | 'fixer'} toolType The type of tool being executed (e.g., 'sniffer', 'fixer').
  * @returns `true` if the document should be processed, `false` otherwise.
  */
 export const shouldProcess = (
   document: TextDocument,
   resourceConf: ResourceSettings,
-  toolType: string,
+  toolType: 'sniffer' | 'fixer',
 ): boolean => {
   let isEnabled = false;
   if (toolType === 'sniffer') {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -107,7 +107,7 @@ const validateAdditionalArguments = (
   // Filter the arguments.
   const filteredArguments = additionalArguments.filter((arg) => {
     // If the argument is an internally added argument, filter it out.
-    if (validInternalArguments.includes(getArgumentKey(arg))) {
+    if (isInternalArgumentKey(getArgumentKey(arg))) {
       isArgValid = false;
       return false;
     }
@@ -308,14 +308,23 @@ const validateFilterValue = (value: string): boolean => {
 /**
  * Extracts the argument key from a command line key-value argument.
  * @param {string} arg The argument (e.g., "--standard=PSR12" or "-q")
- * @returns {PHPCSInternalArgumentKey} The key part (e.g., "--standard" or "-q")
+ * @returns {string} The key part (e.g., "--standard" or "-q")
  */
-const getArgumentKey = (arg: string): PHPCSInternalArgumentKey => {
+const getArgumentKey = (arg: string): string => {
   // If the argument contains an '=', split and return the key part.
   // Otherwise, return the argument as is.
-  return (
-    arg.includes('=') ? arg.split('=', 2)[0] : arg
-  ) as PHPCSInternalArgumentKey;
+  return arg.includes('=') ? arg.split('=', 2)[0] : arg;
+};
+
+/**
+ * Determines whether an argument key is part of the internally-added argument set.
+ * @param {string} key The argument key to test.
+ * @returns {boolean} `true` when the key is an internal argument key.
+ */
+const isInternalArgumentKey = (
+  key: string,
+): key is PHPCSInternalArgumentKey => {
+  return (validInternalArguments as readonly string[]).includes(key);
 };
 
 /**


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to various typings for better type safety.

**Type safety and argument handling:**
* Updated several function signatures to use the string literal type `'sniffer' | 'fixer'` for `toolType` parameters, improving type safety in `src/utils/helpers.ts`.
* Refactored the argument validation logic by splitting out the detection of internal argument keys into a new `isInternalArgumentKey` type guard, and clarified the return type of `getArgumentKey`.
* Improved the handling of additional arguments in `getArgs`, ensuring arguments are validated and concatenated in a type-safe manner.
* Added new `OriginalCommand` interface to better describe the original command of sniffer and fixer for the ENOENT error handling, and updated all references.
* Refactored `snifferMode` property of `Settings` interface to a new `SnifferMode` union type, and updated all other references.

**Other improvements:**
* Initialized `extensionInfo` with default values for its properties to prevent undefined access.
* Fixed the erroneous property name of `warning` to the proper `warnings` in the `PHPCSCounts` interface. This is to prevent any issues arising from the mismatch of names with PHPCS in the future.
* Removed the now redundant `runConfig` enum from sniffer since the new `SnifferMode` type better provides it's type safety.