### PR TITLE
Phpcs v4 and Docker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.1.0] - 2026-05-26
+
+### What's Changed
+
+* **PHP_CodeSniffer 4.x support** (backwards compatible with 3.x).
+  - Handle new PHPCBF exit codes (`4` no fixable errors, `5` fixer conflict, `7` combinations of the above) so v4 runs no longer surface as failures.
+  - Replace the "4.x not supported" warning with version-mismatch detection only.
+  - Clarify 3.x vs 4.x stdout/stderr behaviour in the fixer.
+* **Composer-based phpcs/phpcbf auto-detection.** When `phpsab.executablePathCS`/`CBF` are unset, the extension now uses the workspace `composer.json` (override path via `phpsab.composerJsonPath`) to locate the project-local binaries before falling back to the global PATH.
+* **Optional Docker support.** Run `phpcs` and `phpcbf` inside a container per workspace folder via the new settings (off by default):
+  - `phpsab.dockerEnabled`
+  - `phpsab.dockerContainer`
+  - `phpsab.dockerWorkspaceRoot`
+  - `phpsab.dockerExecutablePathCS` / `phpsab.dockerExecutablePathCBF`
+  - `phpsab.dockerContainerExec` (e.g. `docker` or `podman`)
+  - `phpsab.dockerUseFilepath` (sniffer-only stdin escape hatch)
+
+### Fixed
+
+* Use `cross-spawn` so phpcs/phpcbf invocations no longer fail with `ENOENT` on Windows when the executable path contains spaces or special characters.
+* Fixer error handling for both v3 and v4 — only treat real failures as errors, and stop swallowing diffs returned alongside non-zero exit codes.
+
+
 ## [0.0.25] - 2026-05-09
 
 ### What's Changed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,6 +35,34 @@ To install a development version of this extension for testing you will need to 
 -   Find the option that is `Install from VSIX...` and follow the prompts.
 -   After installing, you may need to reload VSCode.
 
+## Testing Docker mode locally
+
+To exercise the optional Docker support during development, spin up a throwaway container that mounts your test project and has `phpcs`/`phpcbf` installed:
+
+```sh
+# from the test project root
+docker run -d --name phpcs-test -v "$PWD":/app -w /app composer:latest tail -f /dev/null
+docker exec phpcs-test composer global require "squizlabs/php_codesniffer:^3.7"
+# or for PHPCS 4.x:
+# docker exec phpcs-test composer global require "phpcsstandards/php_codesniffer:^4.0"
+```
+
+Then in the test project's `.vscode/settings.json`:
+
+```json
+{
+  "phpsab.dockerEnabled": true,
+  "phpsab.dockerContainer": "phpcs-test",
+  "phpsab.dockerWorkspaceRoot": "/app",
+  "phpsab.dockerExecutablePathCS": "/root/.composer/vendor/bin/phpcs",
+  "phpsab.dockerExecutablePathCBF": "/root/.composer/vendor/bin/phpcbf"
+}
+```
+
+Reload the Extension Development Host. Sniffer/Fixer commands should appear in the output channel as `docker exec -i phpcs-test …`. Stop the container to exercise the "container not running" warning path.
+
+For Podman, set `"phpsab.dockerContainerExec": "podman"` and use `podman run`/`podman exec` in place of `docker`.
+
 ## Publishing Releases
 
 Using the Release system on Github, draft a new release with the desired version tag. The github workflow should handle updating the package.json version and publishing the release to both Vs Marketplace and the Open VSX Registry. These both require a PAT to be set in the security section on github.com and will occasionally need to be updated or rotated if the publishing workflow fails.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ This extension is available on both [VS Code Marketplace](https://marketplace.vi
     - [**phpsab.composerJsonPath**](#phpsabcomposerjsonpath)
     - [**phpsab.phpExecutablePath**](#phpsabphpexecutablepath)
     - [**phpsab.excludeGlobs**](#phpsabexcludeglobs)
+- [Docker support](#docker-support-1)
+    - [Quick start](#quick-start)
+    - [Settings reference](#settings-reference)
+    - [Auto-deriving the container executable paths](#auto-deriving-the-container-executable-paths)
+    - [Notes](#notes)
 - [Diagnosing common errors](#diagnosing-common-errors)
     - [**phpsab.debug**](#phpsabdebug)
     - [The phpcs report contains invalid json](#the-phpcs-report-contains-invalid-json)
@@ -53,11 +58,9 @@ This extension is available on both [VS Code Marketplace](https://marketplace.vi
 
 ## PHPCS Version Support
 
-This extension supports the [latest stable version of PHPCS 3.x](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/). If you are using an older version of PHPCS, please upgrade to the latest 3.x version.
+This extension supports both [PHP_CodeSniffer 3.x](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/) and 4.x. If you are using an older version of PHPCS, please upgrade to a supported 3.x or 4.x release.
 
-> **NOTE:** PHPCS 4.x is not currently supported.
->
-> As of v0.0.22, the extension will detect if PHPCS/PHPCBF version 4.x is being used and will display a warning message to the user. Some features may not work as expected when using version 4.x. Please consider downgrading to the latest 3.x version.
+> **NOTE:** As of v0.1.0, PHPCS 4.x is fully supported. The extension handles the new PHPCBF exit codes (`4`, `5`, `7`) and will only warn when the detected `phpcs`/`phpcbf` binaries are at mismatched major versions.
 
 ## Maintenance Status
 
@@ -154,7 +157,7 @@ This extension is available on both [VS Code Marketplace](https://marketplace.vi
 
 ### Docker support
 
-If you would like to run phpcs in your docker containers using this extension, a [fork exists](https://github.com/mtbdata711/vscode-phpsab-docker) that will provide you with Docker support.
+This extension can run `phpcs` and `phpcbf` inside a running Docker container instead of on the host. Docker mode is opt-in per workspace folder — see the [Docker support](#docker-support-1) section below for the full reference.
 
 ## Basic Configuration
 
@@ -473,6 +476,61 @@ Good Example:
 This setting allows you to specify an array of glob patterns to exclude PHP files from being processed by the Sniffer and Fixer. By default, the `vendor` and `node_modules` directories are excluded.
 
 This is useful for excluding third-party libraries, dependencies, and intellisense stub files that you do not want to be checked or modified by phpcs/phpcbf.
+
+## Docker support
+
+This extension can run `phpcs` and `phpcbf` inside a running Docker container instead of (or alongside) a locally installed binary. Docker mode is opt-in and applies per workspace folder, so a multi-root workspace can mix Docker-enabled folders and local-binary folders freely.
+
+### Quick start
+
+Add the following to your workspace's `.vscode/settings.json`:
+
+```json
+{
+    "phpsab.dockerEnabled": true,
+    "phpsab.dockerContainer": "<container name or ID>",
+    "phpsab.dockerWorkspaceRoot": "<absolute container path matching the host workspace root>"
+}
+```
+
+#### Worked example
+
+If you develop a WordPress plugin at `/home/me/Projects/MyPlugin` on your host, mounted at `/var/www/html/wp-content/plugins/MyPlugin` inside a container named `wordpress`:
+
+```json
+{
+    "phpsab.dockerEnabled": true,
+    "phpsab.dockerContainer": "wordpress",
+    "phpsab.dockerWorkspaceRoot": "/var/www/html/wp-content/plugins/MyPlugin"
+}
+```
+
+The extension will translate the host file path into the container path before invoking `phpcs`, then translate any container paths in the report back to host paths.
+
+### Settings reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `phpsab.dockerEnabled` | `false` | Run `phpcs` and `phpcbf` inside a container. When `false`, all other `phpsab.docker*` settings are ignored. |
+| `phpsab.dockerContainer` | `""` | Name or ID of the running container. Required when `dockerEnabled` is `true`. |
+| `phpsab.dockerWorkspaceRoot` | `""` | Absolute container path that corresponds to the host workspace root. Required when `dockerEnabled` is `true`. |
+| `phpsab.dockerExecutablePathCS` | `""` | Optional. Absolute container path to `phpcs`. If empty, derived from `phpsab.executablePathCS` by replacing the workspace prefix. |
+| `phpsab.dockerExecutablePathCBF` | `""` | Optional. Absolute container path to `phpcbf`. If empty, derived from `phpsab.executablePathCBF`. |
+| `phpsab.dockerContainerExec` | `"docker"` | Single executable used to enter the container. Set to `"podman"` (or an absolute path) for drop-in replacements. Compound commands such as `"docker compose"` are not supported. |
+| `phpsab.dockerUseFilepath` | `false` | Sniffer-only. Pass the file path positionally to `phpcs` instead of streaming via stdin. Disables linting of unsaved buffers; the fixer ignores this setting and always uses stdin mode. |
+
+### Auto-deriving the container executable paths
+
+When `phpsab.dockerExecutablePathCS`/`CBF` is left empty, the extension takes the resolved host executable path (typically a project-local `vendor/bin/phpcs`) and replaces the host workspace prefix with `phpsab.dockerWorkspaceRoot`. This works only when the executable lives under the mounted workspace.
+
+For container-only installations (e.g. `phpcs` at `/usr/local/bin/phpcs` inside the container, with no host counterpart), set `phpsab.dockerExecutablePathCS` and `phpsab.dockerExecutablePathCBF` explicitly.
+
+### Notes
+
+- Docker mode requires an open workspace folder. It is not supported in single-file mode because there is no host workspace root to map.
+- `phpsab.dockerContainer` must be a literal container name or ID. Docker Compose service names are not supported (use `docker exec <container>` semantics).
+- `docker exec` adds noticeable latency. Keeping `phpsab.snifferMode` at the default `"onSave"` is recommended for Docker workspaces.
+- If the container is not running or `phpsab.dockerContainerExec` is not on `PATH`, the extension will warn once and disable the affected tools for that workspace; the rest of the editor remains usable.
 
 ## Diagnosing common errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "vscode-phpsab",
-  "version": "0.0.25",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-phpsab",
-      "version": "0.0.25",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "lodash": "^4.18.1",
         "minimatch": "^10.2.3"
       },
       "devDependencies": {
+        "@types/cross-spawn": "^6.0.6",
         "@types/lodash": "^4.17.21",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22",
@@ -981,6 +983,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -2076,7 +2088,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3053,7 +3064,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3920,7 +3930,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4179,7 +4188,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4192,7 +4200,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4883,7 +4890,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "php",
     "phpcs",
     "phpcbf",
+    "phpcs4",
+    "php_codesniffer",
     "linter",
     "fixer"
   ],

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-phpsab",
   "displayName": "PHP Sniffer & Beautifier",
-  "description": "PHP Sniffer & Beautifier for Visual Studio Code",
-  "version": "0.0.25",
+  "description": "PHP Sniffer & Beautifier for Visual Studio Code, with optional Docker support",
+  "version": "0.1.0",
   "icon": "php_logo.png",
   "publisher": "valeryanm",
   "homepage": "https://github.com/valeryan/vscode-phpsab",
@@ -29,7 +29,8 @@
     "phpcs4",
     "php_codesniffer",
     "linter",
-    "fixer"
+    "fixer",
+    "docker"
   ],
   "activationEvents": [
     "onLanguage:php"
@@ -160,6 +161,48 @@
             "**/node_modules/**"
           ],
           "description": "Glob patterns to exclude PHP files from being processed."
+        },
+        "phpsab.dockerEnabled": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Run phpcs and phpcbf inside a Docker container instead of locally. When false, all other phpsab.docker* settings are ignored."
+        },
+        "phpsab.dockerContainer": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Name or ID of the running container that holds phpcs/phpcbf. Required when dockerEnabled is true."
+        },
+        "phpsab.dockerWorkspaceRoot": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Absolute path inside the container that corresponds to the host workspace root. Required when dockerEnabled is true."
+        },
+        "phpsab.dockerExecutablePathCS": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional. Absolute path to `phpcs` inside the container. If empty, the value of `phpsab.executablePathCS` is rewritten to a container path using `phpsab.dockerWorkspaceRoot`."
+        },
+        "phpsab.dockerExecutablePathCBF": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional. Absolute path to `phpcbf` inside the container. If empty, the value of `phpsab.executablePathCBF` is rewritten to a container path using `phpsab.dockerWorkspaceRoot`."
+        },
+        "phpsab.dockerContainerExec": {
+          "scope": "resource",
+          "type": "string",
+          "default": "docker",
+          "description": "Single executable command used to enter the container (e.g. \"docker\" or \"podman\"). Compound commands such as \"docker compose\" are not supported."
+        },
+        "phpsab.dockerUseFilepath": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Sniffer-only escape hatch: pass the file path to `phpcs` instead of streaming via stdin. Disables linting of unsaved buffers; the fixer always uses stdin mode regardless of this setting."
         }
       }
     }
@@ -176,10 +219,12 @@
     "ts-watch": "tsc --watch -p ./"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.6",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.3"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/lodash": "^4.17.21",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22",

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -176,9 +176,14 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
     args: commandArgs,
   };
 
+  // The hand-rolled ENOENT heuristic only applies when CMD is in the loop
+  // (shell: true) — CMD swallows ENOENT and exits 1. On the cross-spawn /
+  // no-shell path Node populates `fixer.error` with a real ENOENT directly.
   const nodeError =
     (fixer.error as ConsoleError) ||
-    addWindowsEnoentError(fixer, originalCommand, 'spawnSync');
+    (runThroughShell
+      ? addWindowsEnoentError(fixer, originalCommand, 'spawnSync')
+      : null);
 
   logger.info(`FIXER EXIT CODE: ${exitcode}`);
 

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -1,3 +1,4 @@
+import crossSpawn from 'cross-spawn';
 import { spawnSync, SpawnSyncOptions } from 'node:child_process';
 import {
   ConfigurationChangeEvent,
@@ -11,10 +12,13 @@ import {
   workspace,
 } from 'vscode';
 import { ConsoleError } from './interfaces/console-error';
+import { ResourceSettings } from './interfaces/resource-settings';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
+import { toContainerPath } from './resolvers/docker-path-resolver';
 import { createStandardsPathResolver } from './resolvers/standards-path-resolver';
 import { loadSettings } from './settings';
+import { remapStandardForContainer } from './utils/docker-standard';
 import {
   determineNodeError,
   getPhpNotFoundRegex,
@@ -30,10 +34,14 @@ import {
 
 let settingsCache: Settings;
 
-const getSettings = async () => {
-  if (!settingsCache) {
-    settingsCache = await loadSettings();
-  }
+type FixerCommand = {
+  commandPath: string;
+  commandArgs: string[];
+  command: string;
+  runThroughShell: boolean;
+};
+
+const getSettings = () => {
   return settingsCache;
 };
 
@@ -72,7 +80,7 @@ const isFullDocumentRange = (range: Range, document: TextDocument) =>
  * @param document
  */
 const format = async (document: TextDocument, fullDocument: boolean) => {
-  const settings = await getSettings();
+  const settings = getSettings();
   const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
 
   const resourceConf = settings.resources[workspaceFolder?.index ?? 0];
@@ -108,14 +116,32 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
     return '';
   }
 
+  if (resourceConf.dockerEnabled) {
+    standard = await remapStandardForContainer(standard, resourceConf);
+  }
+
+  // Path passed to phpcbf as --stdin-path. The fixer always uses stdin mode
+  // because file mode does not return fixed content on stdout.
+  const filePath = resourceConf.dockerEnabled
+    ? toContainerPath(
+        document.fileName,
+        resourceConf.workspaceRoot ?? '',
+        resourceConf.dockerWorkspaceRoot,
+      )
+    : document.fileName;
+
   const lintArgs = getArgs(
-    document.fileName,
+    filePath,
     standard,
     resourceConf.fixerArguments,
     'fixer',
+    false,
   );
 
   let fileText = document.getText();
+
+  const { commandPath, commandArgs, command, runThroughShell } =
+    buildFixerCommand(resourceConf, lintArgs);
 
   const options: SpawnSyncOptions = {
     cwd:
@@ -128,17 +154,17 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
     // Required to prevent EINVAL errors when spawning .bat files on Windows.
     // https://github.com/valeryan/vscode-phpsab/issues/128
     // https://github.com/nodejs/node/issues/52554
-    shell: true,
+    // Local execution keeps shell mode for .bat/wrapper compatibility.
+    // Docker execution uses cross-spawn without shell to avoid the extra
+    // cmd.exe layer on Windows.
+    shell: runThroughShell,
   };
-
-  const CBFExecutable = resourceConf.executablePathCBF;
-  const parsedArgs = parseArgs(lintArgs);
-
-  const command = constructCommandString(CBFExecutable, parsedArgs);
 
   logger.info(`FIXER COMMAND: ${command}`);
 
-  const fixer = spawnSync(command, options);
+  const fixer = runThroughShell
+    ? spawnSync(command, options)
+    : crossSpawn.sync(commandPath, commandArgs, options);
 
   const exitcode = fixer.status;
   const stdout = fixer.stdout.toString();
@@ -146,8 +172,8 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   // Set the original command information (not parsed) for Windows ENOENT error handling
   const originalCommand = {
-    commandPath: CBFExecutable,
-    args: lintArgs,
+    commandPath,
+    args: commandArgs,
   };
 
   const nodeError =
@@ -324,6 +350,48 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   return result;
 };
+
+/**
+ * Build the spawn command and the original (pre-quoting) command/args used
+ * for Windows ENOENT error reporting. Mirrors `buildSnifferCommand` in
+ * `sniffer.ts`.
+ */
+const buildFixerCommand = (
+  resourceConf: ResourceSettings,
+  lintArgs: string[],
+): FixerCommand => {
+  if (resourceConf.dockerEnabled) {
+    const commandArgs = [
+      'exec',
+      '-i',
+      resourceConf.dockerContainer,
+      resourceConf.dockerExecutablePathCBF,
+      ...lintArgs,
+    ];
+    return {
+      commandPath: resourceConf.dockerContainerExec,
+      commandArgs,
+      command: formatCommandForLog(
+        resourceConf.dockerContainerExec,
+        commandArgs,
+      ),
+      runThroughShell: false,
+    };
+  }
+
+  return {
+    commandPath: resourceConf.executablePathCBF,
+    commandArgs: lintArgs,
+    command: constructCommandString(
+      resourceConf.executablePathCBF,
+      parseArgs(lintArgs),
+    ),
+    runThroughShell: true,
+  };
+};
+
+const formatCommandForLog = (command: string, args: string[]): string =>
+  [command, ...args].join(' ');
 
 /**
  * Check if the fixer output represents successfully fixed code

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -156,11 +156,10 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   logger.info(`FIXER EXIT CODE: ${exitcode}`);
 
-  // We only log STDOUT if it starts with ERROR (3.x versions of phpcbf output "ERROR"
-  // messages to stdout), as otherwise it could be the whole file contents,
-  // which clutters the log when debugging.
-  //
-  // This will be removed once we require phpcbf 4.x, which outputs errors to STDERR.
+  // PHPCS 3.x's phpcbf writes "ERROR" status lines to stdout mixed with the
+  // fixed file content; PHPCS 4.x writes errors to stderr instead. Log stdout
+  // only when it looks like a 3.x error line to avoid dumping fixed file
+  // content into the output channel.
   if (stdout && (stdout.startsWith('ERROR') || stdout.startsWith(getEOL()))) {
     logger.info(`FIXER STDOUT: ${stdout.trim()}`);
   }
@@ -197,11 +196,22 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   }
 
   /**
-   * fixer exit codes:
-   * Exit code 0 is used to indicate that no fixable errors were found, so nothing was fixed
-   * Exit code 1 is used to indicate that all fixable errors were fixed correctly
-   * Exit code 2 is used to indicate that FIXER failed to fix some of the fixable errors it found
-   * Exit code 3 is used for general script execution errors
+   * PHPCBF exit codes:
+   *
+   * PHP_CodeSniffer 3.x:
+   * 0: no fixable errors were found, so nothing was fixed
+   * 1: all fixable errors were fixed correctly
+   * 2: PHPCBF failed to fix some of the fixable errors it found
+   * 3: processing / script execution error
+   *
+   * PHP_CodeSniffer 4.x:
+   * 0: clean / auto-fixed with no remaining issues
+   * 1: issues found/remaining, auto-fixable
+   * 2: issues found/remaining, non-auto-fixable
+   * 4: failure to fix some files / fixer conflict (phpcbf only)
+   * 5: 1 + 4 (phpcbf only)
+   * 7: 1 + 2 + 4 (phpcbf only)
+   * 16, 64: processing / requirements errors
    */
   switch (exitcode) {
     case null: {
@@ -243,6 +253,25 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
     case 2: {
       // If stdout has valid fixed output (and doesn't contain error messages),
       // then this exit code indicates that some fixable errors failed to be fixed.
+      if (hasValidFixedOutput(stdout, fileText)) {
+        result = fixed;
+        message = 'FIXER failed to fix some of the fixable errors.';
+      }
+      // If Node errors.
+      else if (nodeError) {
+        // Destructure the returned object and assign to variables.
+        ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
+        error += errorMsg;
+      }
+
+      break;
+    }
+    // PHPCS 4.x: fixer conflict (4) and combinations 5=1+4, 7=1+2+4.
+    case 4:
+    case 5:
+    case 7: {
+      // If stdout has valid fixed output (and doesn't contain error messages),
+      // then apply it even though some fixable errors failed to be fixed.
       if (hasValidFixedOutput(stdout, fileText)) {
         result = fixed;
         message = 'FIXER failed to fix some of the fixable errors.';

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -201,12 +201,13 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   let fixed = stdout;
 
-  let errors: { [key: number]: string } = {
-    3: 'FIXER: A general script execution error occurred.',
-    16: 'FIXER: Configuration error of the application.',
-    32: 'FIXER: Configuration error of a Fixer.',
-    64: 'FIXER: Exception raised within the application.',
-    255: 'FIXER: A Fatal execution error occurred.',
+  // PHPCS-specific exit-code labels. (Earlier versions of this map used
+  // PHP-CS-Fixer labels by mistake — different tool, different codes.)
+  const errors: { [key: number]: string } = {
+    3: 'FIXER: Processing / script execution error (PHPCS 3.x).',
+    16: 'FIXER: Processing error — invalid CLI options or ruleset (PHPCS 4.x).',
+    64: 'FIXER: Requirements not met — PHP version or missing extensions (PHPCS 4.x).',
+    255: 'FIXER: A fatal execution error occurred.',
   };
 
   let error: string = '';
@@ -281,75 +282,53 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
       break;
     }
-    case 2: {
-      // If stdout has valid fixed output (and doesn't contain error messages),
-      // then this exit code indicates that some fixable errors failed to be fixed.
-      if (hasValidFixedOutput(stdout, fileText)) {
-        result = fixed;
-        message = 'FIXER failed to fix some of the fixable errors.';
-      }
-      // If Node errors.
-      else if (nodeError) {
-        // Destructure the returned object and assign to variables.
-        ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
-        error += errorMsg;
-      }
-
-      break;
-    }
-    // PHPCS 4.x: fixer conflict (4) and combinations 5=1+4, 7=1+2+4.
+    // 2 has different meanings between versions:
+    //  - PHPCS 3.x phpcbf: some fixable errors failed to fix.
+    //  - PHPCS 4.x phpcbf (NON_FIXABLE): auto-fixable were fixed, but
+    //    non-auto-fixable issues remain.
+    // 4 / 5 / 7 are PHPCS 4.x bitmask combinations involving FAILED_TO_FIX.
+    // In every case, stdout (when valid) contains the partially / fully fixed
+    // file and should be applied. The user-facing message is unified — neutral
+    // wording that's accurate for both versions.
+    case 2:
     case 4:
     case 5:
     case 7: {
-      // If stdout has valid fixed output (and doesn't contain error messages),
-      // then apply it even though some fixable errors failed to be fixed.
       if (hasValidFixedOutput(stdout, fileText)) {
         result = fixed;
-        message = 'FIXER failed to fix some of the fixable errors.';
-      }
-      // If Node errors.
-      else if (nodeError) {
-        // Destructure the returned object and assign to variables.
+        message = 'FIXER applied auto-fixes; some issues could not be auto-fixed.';
+      } else if (nodeError) {
         ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
         error += errorMsg;
+      } else {
+        // No fixes applied (e.g. PHPCS 4.x exit 2 with only non-fixable issues,
+        // or 3.x exit 2 where every fix attempt failed). Inform without error.
+        message = 'No auto-fixable issues were applied; non-auto-fixable issues remain.';
       }
 
       break;
     }
     default:
-      // A PHPCBF error occurred.
+      // A PHPCBF error occurred. stdout has already been logged above; don't
+      // splat it into the user's error dialog.
       error =
         errors[exitcode] ||
         `FIXER: An unknown error occurred with exit code ${exitcode}.`;
-      if (fixed.length > 0) {
-        error += '\n' + fixed + '\n';
-      }
-      // Other errors.
-      else {
-        // If Node errors.
-        if (nodeError) {
-          // Destructure the returned object and assign to variables.
-          ({ errorMsg, extraLoggerMsg } = determineNodeError(
-            nodeError,
-            'fixer',
-          ));
-          error += errorMsg;
-        }
-        // If no specific error is found, return a generic fatal error.
-        else {
-          error += 'FATAL: Unknown error occurred.';
-        }
+      if (nodeError) {
+        ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
+        error += ` ${errorMsg}`;
       }
   }
 
   logger.endTimer('Fixer');
 
-  window.showInformationMessage(message);
-
   if (error !== '') {
     logger.error(`${error}${extraLoggerMsg}`);
     return Promise.reject(error);
-  } else {
+  }
+
+  if (message !== '') {
+    window.showInformationMessage(message);
     logger.info(`FIXER MESSAGE: ${message}`);
   }
 

--- a/src/interfaces/resource-settings.ts
+++ b/src/interfaces/resource-settings.ts
@@ -11,4 +11,11 @@ export interface ResourceSettings {
   autoRulesetSearch: boolean;
   allowedAutoRulesets: string[];
   excludeGlobs: string[];
+  dockerEnabled: boolean;
+  dockerContainer: string;
+  dockerWorkspaceRoot: string;
+  dockerExecutablePathCS: string;
+  dockerExecutablePathCBF: string;
+  dockerContainerExec: string;
+  dockerUseFilepath: boolean;
 }

--- a/src/resolvers/docker-path-resolver.ts
+++ b/src/resolvers/docker-path-resolver.ts
@@ -1,0 +1,106 @@
+import path from 'node:path';
+import { isWin } from './path-resolver-utils';
+
+const toPosix = (input: string): string => input.replace(/\\/g, '/');
+
+const stripTrailingSlash = (input: string): string =>
+  input.endsWith('/') && input.length > 1 ? input.slice(0, -1) : input;
+
+const hasPathBoundaryPrefix = (inputPath: string, prefix: string): boolean => {
+  const remainder = inputPath.slice(prefix.length);
+  return remainder.length === 0 || remainder.startsWith('/');
+};
+
+export const isHostPathInsideWorkspace = (
+  hostPath: string,
+  hostWorkspaceRoot: string,
+): boolean => {
+  if (!hostPath || !hostWorkspaceRoot) {
+    return false;
+  }
+
+  const normalisedHost = toPosix(hostPath);
+  const normalisedRoot = stripTrailingSlash(toPosix(hostWorkspaceRoot));
+
+  const hostForCompare = isWin()
+    ? normalisedHost.toLowerCase()
+    : normalisedHost;
+  const rootForCompare = isWin()
+    ? normalisedRoot.toLowerCase()
+    : normalisedRoot;
+
+  return (
+    hostForCompare.startsWith(rootForCompare) &&
+    hasPathBoundaryPrefix(hostForCompare, rootForCompare)
+  );
+};
+
+/**
+ * Translate a host filesystem path into the equivalent path inside the Docker
+ * container, by replacing the host workspace root prefix with the container
+ * workspace root.
+ *
+ * Returns the input unchanged when:
+ * - either workspace root is empty (Docker is misconfigured); OR
+ * - the input does not lie under the host workspace root (caller decides what
+ *   to do — typically files outside the workspace can't be linted in-container).
+ *
+ * The match is performed on a path-segment boundary, so a host path like
+ * `/repo/app2/file.php` is not remapped when the workspace is `/repo/app`.
+ */
+export const toContainerPath = (
+  hostPath: string,
+  hostWorkspaceRoot: string,
+  containerWorkspaceRoot: string,
+): string => {
+  if (!hostPath || !hostWorkspaceRoot || !containerWorkspaceRoot) {
+    return hostPath;
+  }
+
+  const normalisedHost = toPosix(hostPath);
+  const normalisedRoot = stripTrailingSlash(toPosix(hostWorkspaceRoot));
+  const normalisedContainerRoot = stripTrailingSlash(
+    toPosix(containerWorkspaceRoot),
+  );
+
+  if (!isHostPathInsideWorkspace(hostPath, hostWorkspaceRoot)) {
+    return hostPath;
+  }
+
+  const remainder = normalisedHost.slice(normalisedRoot.length);
+  return normalisedContainerRoot + remainder;
+};
+
+/**
+ * Translate a container path back to the equivalent host filesystem path.
+ *
+ * Same boundary/normalisation rules as {@link toContainerPath}. The output is
+ * normalised through `path.normalize` on Windows so VS Code URI matching works
+ * with backslashes.
+ */
+export const toHostPath = (
+  containerPath: string,
+  hostWorkspaceRoot: string,
+  containerWorkspaceRoot: string,
+): string => {
+  if (!containerPath || !hostWorkspaceRoot || !containerWorkspaceRoot) {
+    return containerPath;
+  }
+
+  const normalisedContainer = toPosix(containerPath);
+  const normalisedContainerRoot = stripTrailingSlash(
+    toPosix(containerWorkspaceRoot),
+  );
+  const normalisedHostRoot = stripTrailingSlash(toPosix(hostWorkspaceRoot));
+
+  if (
+    !normalisedContainer.startsWith(normalisedContainerRoot) ||
+    !hasPathBoundaryPrefix(normalisedContainer, normalisedContainerRoot)
+  ) {
+    return containerPath;
+  }
+
+  const remainder = normalisedContainer.slice(normalisedContainerRoot.length);
+  const joined = normalisedHostRoot + remainder;
+  return isWin() ? path.normalize(joined) : joined;
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,13 +5,21 @@ import { Uri, WorkspaceConfiguration, window, workspace } from 'vscode';
 import { ResourceSettings } from './interfaces/resource-settings';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
+import {
+  isHostPathInsideWorkspace,
+  toContainerPath,
+} from './resolvers/docker-path-resolver';
 import { createPathResolver } from './resolvers/path-resolver';
 import {
   addPhpToEnvPath,
   joinPaths,
   normalizePath,
 } from './resolvers/path-resolver-utils';
-import { getExtensionInfo } from './utils/helpers';
+import {
+  constructCommandString,
+  getExtensionInfo,
+  parseArgs,
+} from './utils/helpers';
 
 /**
  * Check if the editor is in single file mode.
@@ -34,16 +42,65 @@ const resolveRootPath = (resource: Uri) => {
 };
 
 /**
+ * Whether the resource has an explicit container-side phpcbf path the
+ * extension can use directly without resolving anything on the host.
+ */
+const hasExplicitDockerCBF = (settings: ResourceSettings): boolean =>
+  settings.dockerEnabled && settings.dockerExecutablePathCBF.length > 0;
+
+/**
+ * Whether the resource has an explicit container-side phpcs path the
+ * extension can use directly without resolving anything on the host.
+ */
+const hasExplicitDockerCS = (settings: ResourceSettings): boolean =>
+  settings.dockerEnabled && settings.dockerExecutablePathCS.length > 0;
+
+const deriveDockerExecutablePath = (
+  settings: ResourceSettings,
+  hostExecutablePath: string,
+): string => {
+  if (
+    !hostExecutablePath ||
+    !settings.workspaceRoot ||
+    !settings.dockerWorkspaceRoot ||
+    !isHostPathInsideWorkspace(hostExecutablePath, settings.workspaceRoot)
+  ) {
+    return '';
+  }
+
+  return toContainerPath(
+    hostExecutablePath,
+    settings.workspaceRoot,
+    settings.dockerWorkspaceRoot,
+  );
+};
+
+/**
  * Get correct executable path from resolver
  * @param settings
  */
 const resolveCBFExecutablePath = async (
   settings: ResourceSettings,
 ): Promise<ResourceSettings> => {
+  // Docker mode with an explicit container path: don't resolve anything on the host.
+  if (hasExplicitDockerCBF(settings)) {
+    return settings;
+  }
+
   // If no path is set, try and find it via the path resolver.
   if (!settings.executablePathCBF) {
     let executablePathResolver = createPathResolver(settings, 'phpcbf');
-    settings.executablePathCBF = await executablePathResolver.resolve();
+    try {
+      settings.executablePathCBF = await executablePathResolver.resolve();
+    } catch (error) {
+      // In Docker mode without an explicit container path, an unresolved host
+      // path is fatal: we have nothing to remap into the container.
+      if (settings.dockerEnabled) {
+        settings.executablePathCBF = '';
+      } else {
+        throw error;
+      }
+    }
   }
   // If a relative path is set, resolve it against the workspace root.
   else if (
@@ -60,6 +117,15 @@ const resolveCBFExecutablePath = async (
     settings.executablePathCBF = normalizePath(settings.executablePathCBF);
   }
 
+  // In Docker mode without an explicit container path, derive one from the host
+  // path by remapping the workspace root prefix into the container.
+  if (settings.dockerEnabled && !settings.dockerExecutablePathCBF) {
+    settings.dockerExecutablePathCBF = deriveDockerExecutablePath(
+      settings,
+      settings.executablePathCBF,
+    );
+  }
+
   return settings;
 };
 
@@ -70,10 +136,22 @@ const resolveCBFExecutablePath = async (
 const resolveCSExecutablePath = async (
   settings: ResourceSettings,
 ): Promise<ResourceSettings> => {
+  if (hasExplicitDockerCS(settings)) {
+    return settings;
+  }
+
   // If no path is set, try and find it via the path resolver.
   if (!settings.executablePathCS) {
     let executablePathResolver = createPathResolver(settings, 'phpcs');
-    settings.executablePathCS = await executablePathResolver.resolve();
+    try {
+      settings.executablePathCS = await executablePathResolver.resolve();
+    } catch (error) {
+      if (settings.dockerEnabled) {
+        settings.executablePathCS = '';
+      } else {
+        throw error;
+      }
+    }
   }
   // If a relative path is set, resolve it against the workspace root.
   else if (
@@ -88,6 +166,13 @@ const resolveCSExecutablePath = async (
   // Otherwise normalize the absolute path.
   else {
     settings.executablePathCS = normalizePath(settings.executablePathCS);
+  }
+
+  if (settings.dockerEnabled && !settings.dockerExecutablePathCS) {
+    settings.dockerExecutablePathCS = deriveDockerExecutablePath(
+      settings,
+      settings.executablePathCS,
+    );
   }
 
   return settings;
@@ -142,28 +227,165 @@ const executableExist = async (path: string) => {
   }
 };
 
+/**
+ * Probe whether a given path exists as a regular file inside the configured
+ * Docker container by running `<containerExec> exec -i <container> test -f <path>`.
+ *
+ * Returns `true` only when the probe runs and `test -f` succeeds (exit 0).
+ */
+const dockerExecutableExist = (
+  containerPath: string,
+  settings: ResourceSettings,
+): boolean => {
+  if (
+    !containerPath ||
+    !settings.dockerContainer ||
+    !settings.dockerContainerExec
+  ) {
+    return false;
+  }
+
+  const command = constructCommandString(
+    settings.dockerContainerExec,
+    parseArgs([
+      'exec',
+      '-i',
+      settings.dockerContainer,
+      'test',
+      '-f',
+      containerPath,
+    ]),
+  );
+
+  try {
+    const result = spawnSync(command, {
+      cwd: settings.workspaceRoot ?? undefined,
+      env: process.env,
+      encoding: 'utf8',
+      shell: true,
+      timeout: 5000,
+    });
+
+    if (result.error) {
+      logger.debug(
+        `Docker probe for "${containerPath}" failed: ${result.error.message}`,
+      );
+      return false;
+    }
+
+    return result.status === 0;
+  } catch (error) {
+    logger.debug(
+      `Docker probe for "${containerPath}" threw: ${(error as Error).message}`,
+    );
+    return false;
+  }
+};
+
+/**
+ * Make sure the resource has the minimum Docker configuration the rest of
+ * the pipeline relies on. Disables both tools and returns a warning string
+ * (or `''`) on misconfiguration.
+ */
+const validateDockerConfig = (
+  settings: ResourceSettings,
+  resource: string,
+): string => {
+  if (!settings.dockerEnabled) {
+    return '';
+  }
+
+  const missing: string[] = [];
+  if (!settings.workspaceRoot) {
+    missing.push(
+      'a workspace folder (Docker mode is not supported in single-file mode)',
+    );
+  }
+  if (!settings.dockerContainer) {
+    missing.push('"phpsab.dockerContainer"');
+  }
+  if (!settings.dockerWorkspaceRoot) {
+    missing.push('"phpsab.dockerWorkspaceRoot"');
+  }
+  if (!settings.dockerContainerExec) {
+    missing.push('"phpsab.dockerContainerExec"');
+  }
+
+  if (missing.length === 0) {
+    return '';
+  }
+
+  settings.snifferEnable = false;
+  settings.fixerEnable = false;
+  return `Docker mode is enabled for "${resource}" but is missing required settings: ${missing.join(', ')}. Sniffer and Fixer are being disabled for this workspace.`;
+};
+
 const validate = async (
   settings: ResourceSettings,
   resource: string,
 ): Promise<ResourceSettings> => {
-  let msg = '';
-  if (
-    settings.snifferEnable &&
-    !(await executableExist(settings.executablePathCS))
-  ) {
-    msg = `The phpcs executable was not found for ${resource}. Sniffer is being disabled for this workspace.`;
-    settings.snifferEnable = false;
-  }
-  if (
-    settings.fixerEnable &&
-    !(await executableExist(settings.executablePathCBF))
-  ) {
-    msg = `The phpcbf executable was not found for ${resource}. Fixer is being disabled for this workspace.`;
-    settings.fixerEnable = false;
+  const warnings: string[] = [];
+
+  // Docker config sanity check first; if it fails the host checks would be misleading.
+  const dockerConfigWarning = validateDockerConfig(settings, resource);
+  if (dockerConfigWarning) {
+    warnings.push(dockerConfigWarning);
   }
 
-  logger.log(msg);
-  window.showWarningMessage(msg, 'OK');
+  if (settings.dockerEnabled) {
+    if (settings.snifferEnable) {
+      const csPath = settings.dockerExecutablePathCS;
+      if (!csPath) {
+        warnings.push(
+          `Could not determine a phpcs path inside container "${settings.dockerContainer}" for ${resource}. Set "phpsab.dockerExecutablePathCS" or place phpcs under the mounted workspace. Sniffer is being disabled for this workspace.`,
+        );
+        settings.snifferEnable = false;
+      } else if (!dockerExecutableExist(csPath, settings)) {
+        warnings.push(
+          `Failed to verify phpcs in container "${settings.dockerContainer}" at "${csPath}" for ${resource}. Sniffer is being disabled for this workspace.`,
+        );
+        settings.snifferEnable = false;
+      }
+    }
+    if (settings.fixerEnable) {
+      const cbfPath = settings.dockerExecutablePathCBF;
+      if (!cbfPath) {
+        warnings.push(
+          `Could not determine a phpcbf path inside container "${settings.dockerContainer}" for ${resource}. Set "phpsab.dockerExecutablePathCBF" or place phpcbf under the mounted workspace. Fixer is being disabled for this workspace.`,
+        );
+        settings.fixerEnable = false;
+      } else if (!dockerExecutableExist(cbfPath, settings)) {
+        warnings.push(
+          `Failed to verify phpcbf in container "${settings.dockerContainer}" at "${cbfPath}" for ${resource}. Fixer is being disabled for this workspace.`,
+        );
+        settings.fixerEnable = false;
+      }
+    }
+  } else {
+    if (
+      settings.snifferEnable &&
+      !(await executableExist(settings.executablePathCS))
+    ) {
+      warnings.push(
+        `The phpcs executable was not found for ${resource}. Sniffer is being disabled for this workspace.`,
+      );
+      settings.snifferEnable = false;
+    }
+    if (
+      settings.fixerEnable &&
+      !(await executableExist(settings.executablePathCBF))
+    ) {
+      warnings.push(
+        `The phpcbf executable was not found for ${resource}. Fixer is being disabled for this workspace.`,
+      );
+      settings.fixerEnable = false;
+    }
+  }
+
+  for (const msg of warnings) {
+    logger.log(msg);
+    window.showWarningMessage(msg, 'OK');
+  }
 
   return settings;
 };
@@ -265,6 +487,13 @@ const getSettings = async (
       '**/vendor/**',
       '**/node_modules/**',
     ]),
+    dockerEnabled: config.get('dockerEnabled', false),
+    dockerContainer: config.get('dockerContainer', ''),
+    dockerWorkspaceRoot: config.get('dockerWorkspaceRoot', ''),
+    dockerExecutablePathCS: config.get('dockerExecutablePathCS', ''),
+    dockerExecutablePathCBF: config.get('dockerExecutablePathCBF', ''),
+    dockerContainerExec: config.get('dockerContainerExec', 'docker'),
+    dockerUseFilepath: config.get('dockerUseFilepath', false),
   };
 
   settings = await resolveCBFExecutablePath(settings);
@@ -287,17 +516,20 @@ const checkPhpcsVersionCompatibility = async (
     let phpcbfVersion: string | null = null;
     const resourceRoot = path.basename(resourceSettings.workspaceRoot || '');
 
-    const phpcsExecutablePath = resourceSettings.executablePathCS;
-    const phpcbfExecutablePath = resourceSettings.executablePathCBF;
-
     // If sniffer is enabled and PHPCS executable found, check it's version.
-    if (resourceSettings.snifferEnable && phpcsExecutablePath) {
-      phpcsVersion = await getPhpcsVersion(phpcsExecutablePath, 'PHPCS');
+    if (resourceSettings.snifferEnable) {
+      phpcsVersion = await getPhpcsVersionForResource(
+        resourceSettings,
+        'PHPCS',
+      );
     }
 
     // If fixer is enabled and PHPCBF executable found, check it's version.
-    if (resourceSettings.fixerEnable && phpcbfExecutablePath) {
-      phpcbfVersion = await getPhpcsVersion(phpcbfExecutablePath, 'PHPCBF');
+    if (resourceSettings.fixerEnable) {
+      phpcbfVersion = await getPhpcsVersionForResource(
+        resourceSettings,
+        'PHPCBF',
+      );
     }
 
     let warningMsg = '';
@@ -335,6 +567,38 @@ const checkPhpcsVersionCompatibility = async (
 };
 
 /**
+ * Resolve and run `--version` for either tool, host- or container-side
+ * depending on the resource configuration.
+ */
+const getPhpcsVersionForResource = async (
+  resourceSettings: ResourceSettings,
+  executableName: 'PHPCS' | 'PHPCBF',
+): Promise<string | null> => {
+  if (resourceSettings.dockerEnabled) {
+    const containerExecutable =
+      executableName === 'PHPCS'
+        ? resourceSettings.dockerExecutablePathCS
+        : resourceSettings.dockerExecutablePathCBF;
+
+    if (!containerExecutable) {
+      return null;
+    }
+
+    return getDockerPhpcsVersion(
+      resourceSettings,
+      containerExecutable,
+      executableName,
+    );
+  }
+
+  const hostExecutable =
+    executableName === 'PHPCS'
+      ? resourceSettings.executablePathCS
+      : resourceSettings.executablePathCBF;
+  return getPhpcsVersion(hostExecutable, executableName);
+};
+
+/**
  * Get the version of PHPCS or PHPCBF
  * @param {string} executablePath The path to the PHPCS or PHPCBF executable
  * @param {string} executableName The name of the executable (phpcs or phpcbf) for logging
@@ -349,15 +613,52 @@ const getPhpcsVersion = async (
     return null;
   }
 
+  const command = constructCommandString(
+    executablePath,
+    parseArgs(['--version']),
+  );
+  return runVersionProbe(command, executableName);
+};
+
+/**
+ * Run `--version` against an executable inside a Docker container.
+ */
+const getDockerPhpcsVersion = async (
+  resourceSettings: ResourceSettings,
+  containerExecutable: string,
+  executableName: string,
+): Promise<string | null> => {
+  if (
+    !resourceSettings.dockerContainer ||
+    !resourceSettings.dockerContainerExec
+  ) {
+    return null;
+  }
+
+  const command = constructCommandString(
+    resourceSettings.dockerContainerExec,
+    parseArgs([
+      'exec',
+      '-i',
+      resourceSettings.dockerContainer,
+      containerExecutable,
+      '--version',
+    ]),
+  );
+  return runVersionProbe(command, executableName);
+};
+
+const runVersionProbe = (
+  command: string,
+  executableName: string,
+): string | null => {
   try {
-    // Run the executable with --version
-    const result = spawnSync(`"${executablePath}" --version`, {
+    const result = spawnSync(command, {
       encoding: 'utf8',
       shell: true,
       timeout: 5000,
     });
 
-    // If the process failed, log the error and return null.
     if (result.status !== 0 || result.error) {
       logger.debug(
         `Failed to get ${executableName} version: ${result.error?.message || result.stderr}`,
@@ -365,22 +666,14 @@ const getPhpcsVersion = async (
       return null;
     }
 
-    // Get the output.
     const output = result.stdout.toString().trim();
 
-    // Verify that the matched string contains "PHP_CodeSniffer".
-    // This ensures it's the correct executable.
     if (!output.includes('PHP_CodeSniffer')) {
-      const errorMsg = `Invalid output string for ${executableName}: ${output}`;
-      logger.debug(errorMsg);
-
-      throw new Error(errorMsg);
+      logger.debug(`Invalid output string for ${executableName}: ${output}`);
+      return null;
     }
 
-    // Match version patterns like "PHP_CodeSniffer version 3.7.2".
     const versionMatch = output.match(/(\d+)\.(\d+)\.(\d+)/);
-
-    // If no version match is found, log and return null.
     if (!versionMatch) {
       logger.debug(
         `Could not obtain ${executableName} version from output:`,
@@ -389,17 +682,12 @@ const getPhpcsVersion = async (
       return null;
     }
 
-    // Get the full version string from the match array.
     const version = versionMatch[0];
-
     logger.info(`${executableName} version: ${version}`);
-
     return version;
   } catch (error) {
-    // Log any exceptions and return null.
     const errorMsg = `Exception while getting the ${executableName} version: ${error}`;
     logger.debug(errorMsg);
-    window.showErrorMessage(errorMsg, 'OK');
     return null;
   }
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -274,7 +274,7 @@ const getSettings = async (
 };
 
 /**
- * Check PHPCS version compatibility and warn on 4.x versions.
+ * Check PHPCS version compatibility.
  * @param {Settings} settings The extension settings
  * @return {Promise<void>}
  */
@@ -324,14 +324,6 @@ const checkPhpcsVersionCompatibility = async (
     // Check for version mismatches when both versions are available
     else if (phpcsVersion && phpcbfVersion && phpcsVersion !== phpcbfVersion) {
       warningMsg = `Version mismatch detected: PHPCS version ${phpcsVersion} and PHPCBF version ${phpcbfVersion} from "${resourceRoot}". This may lead to unexpected behavior. Please ensure both are from the same installation directory.`;
-    }
-    // Check for unsupported 4.x versions
-    else if (
-      (phpcsVersion && phpcsVersion.startsWith('4.')) ||
-      (phpcbfVersion && phpcbfVersion.startsWith('4.'))
-    ) {
-      const version = phpcsVersion || phpcbfVersion;
-      warningMsg = `Version ${version} detected in "${resourceRoot}". Version 4.x is not supported yet. Some features may not work as expected. Please consider downgrading to the latest 3.x version.`;
     }
 
     // Only show warning if there's a message to display.

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -1,3 +1,4 @@
+import crossSpawn from 'cross-spawn';
 import { debounce } from 'lodash';
 import { spawn, SpawnOptions } from 'node:child_process';
 import {
@@ -16,11 +17,18 @@ import {
   workspace,
 } from 'vscode';
 import { ConsoleError } from './interfaces/console-error';
-import { PHPCSMessageType, PHPCSReport } from './interfaces/phpcs-report';
+import {
+  PHPCSFileStatus,
+  PHPCSMessageType,
+  PHPCSReport,
+} from './interfaces/phpcs-report';
+import { ResourceSettings } from './interfaces/resource-settings';
 import { Settings } from './interfaces/settings';
 import { logger } from './logger';
+import { toContainerPath, toHostPath } from './resolvers/docker-path-resolver';
 import { createStandardsPathResolver } from './resolvers/standards-path-resolver';
 import { loadSettings } from './settings';
+import { remapStandardForContainer } from './utils/docker-standard';
 import {
   determineNodeError,
   getPhpNotFoundRegex,
@@ -42,6 +50,13 @@ let settingsCache: Settings;
 const diagnosticCollection: DiagnosticCollection =
   languages.createDiagnosticCollection('php');
 
+type SnifferCommand = {
+  commandPath: string;
+  commandArgs: string[];
+  command: string;
+  runThroughShell: boolean;
+};
+
 /**
  * The active validator listener.
  */
@@ -52,10 +67,7 @@ let validatorListener: Disposable;
  */
 const runnerCancellations: Map<Uri, CancellationTokenSource> = new Map();
 
-const getSettings = async () => {
-  if (!settingsCache) {
-    settingsCache = await loadSettings();
-  }
+const getSettings = () => {
   return settingsCache;
 };
 
@@ -67,7 +79,7 @@ const getSettings = async () => {
 const validate = async (document: TextDocument) => {
   const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
 
-  const settings = await getSettings();
+  const settings = getSettings();
   const resourceConf = settings.resources[workspaceFolder?.index ?? 0];
 
   // If the document should not be processed, return early.
@@ -101,14 +113,35 @@ const validate = async (document: TextDocument) => {
     return;
   }
 
+  if (resourceConf.dockerEnabled) {
+    standard = await remapStandardForContainer(standard, resourceConf);
+  }
+
+  // Path passed to phpcs as --stdin-path (or as the positional file in file mode).
+  const filePath = resourceConf.dockerEnabled
+    ? toContainerPath(
+        document.fileName,
+        resourceConf.workspaceRoot ?? '',
+        resourceConf.dockerWorkspaceRoot,
+      )
+    : document.fileName;
+
+  // dockerUseFilepath is sniffer-only; the fixer ignores it.
+  const useFilepath =
+    resourceConf.dockerEnabled && resourceConf.dockerUseFilepath;
+
   const lintArgs = getArgs(
-    document.fileName,
+    filePath,
     standard,
     resourceConf.snifferArguments,
     'sniffer',
+    useFilepath,
   );
 
   let fileText = document.getText();
+
+  const { commandPath, commandArgs, command, runThroughShell } =
+    buildSnifferCommand(resourceConf, lintArgs);
 
   const options: SpawnOptions = {
     cwd:
@@ -119,28 +152,30 @@ const validate = async (document: TextDocument) => {
     // Required to prevent EINVAL errors when spawning .bat files on Windows.
     // https://github.com/valeryan/vscode-phpsab/issues/128
     // https://github.com/nodejs/node/issues/52554
-    shell: true,
+    // Local execution keeps shell mode for .bat/wrapper compatibility.
+    // Docker execution uses cross-spawn without shell to avoid the extra
+    // cmd.exe layer on Windows.
+    shell: runThroughShell,
   };
-
-  const CSExecutable = resourceConf.executablePathCS;
-  const parsedArgs = parseArgs(lintArgs);
-
-  const command = constructCommandString(CSExecutable, parsedArgs);
 
   logger.info(`SNIFFER COMMAND: ${command}`);
 
-  const sniffer = spawn(command, options);
+  const sniffer = runThroughShell
+    ? spawn(command, options)
+    : crossSpawn(commandPath, commandArgs, options);
 
   // Set the original command information (not parsed) for Windows ENOENT error handling
   const originalCommand = {
-    commandPath: CSExecutable,
-    args: lintArgs,
+    commandPath,
+    args: commandArgs,
   };
 
   addWindowsEnoentError(sniffer, originalCommand, 'spawn');
 
   if (sniffer.stdin) {
-    sniffer.stdin.write(fileText);
+    if (!useFilepath) {
+      sniffer.stdin.write(fileText);
+    }
     sniffer.stdin.end();
   } else {
     // Kill the process if we can't write to its `stdin`. We use `SIGKILL` to forcefully
@@ -205,7 +240,24 @@ const validate = async (document: TextDocument) => {
       const diagnostics: Diagnostic[] = [];
       // try-catch to handle JSON parse errors
       try {
-        const { files }: PHPCSReport = JSON.parse(stdout);
+        let { files }: PHPCSReport = JSON.parse(stdout);
+
+        // Remap container-side report keys back to host paths so any
+        // multi-file report iteration lines up with VS Code documents.
+        if (resourceConf.dockerEnabled) {
+          files = Object.entries(files).reduce<{
+            [key: string]: PHPCSFileStatus;
+          }>((carry, [reportPath, status]) => {
+            const hostKey = toHostPath(
+              reportPath,
+              resourceConf.workspaceRoot ?? '',
+              resourceConf.dockerWorkspaceRoot,
+            );
+            carry[hostKey] = status;
+            return carry;
+          }, {});
+        }
+
         for (const file in files) {
           files[file].messages.forEach(
             ({ message, line, column, type, source, fixable }) => {
@@ -264,6 +316,50 @@ const validate = async (document: TextDocument) => {
 };
 
 /**
+ * Build the spawn command and the original (pre-quoting) command/args used
+ * for Windows ENOENT error reporting.
+ *
+ * In Docker mode the command is `<dockerContainerExec> exec -i <container>
+ * <dockerExecutablePathCS> …lintArgs`; in local mode it's `<executablePathCS> …lintArgs`.
+ */
+const buildSnifferCommand = (
+  resourceConf: ResourceSettings,
+  lintArgs: string[],
+): SnifferCommand => {
+  if (resourceConf.dockerEnabled) {
+    const commandArgs = [
+      'exec',
+      '-i',
+      resourceConf.dockerContainer,
+      resourceConf.dockerExecutablePathCS,
+      ...lintArgs,
+    ];
+    return {
+      commandPath: resourceConf.dockerContainerExec,
+      commandArgs,
+      command: formatCommandForLog(
+        resourceConf.dockerContainerExec,
+        commandArgs,
+      ),
+      runThroughShell: false,
+    };
+  }
+
+  return {
+    commandPath: resourceConf.executablePathCS,
+    commandArgs: lintArgs,
+    command: constructCommandString(
+      resourceConf.executablePathCS,
+      parseArgs(lintArgs),
+    ),
+    runThroughShell: true,
+  };
+};
+
+const formatCommandForLog = (command: string, args: string[]): string =>
+  [command, ...args].join(' ');
+
+/**
  * Refreshes validation on any open documents.
  */
 const refresh = (): void => {
@@ -288,7 +384,7 @@ const setValidatorListener = async (): Promise<void> => {
   if (validatorListener) {
     validatorListener.dispose();
   }
-  const settings = await getSettings();
+  const settings = getSettings();
   const run: runConfig = settings.snifferMode as runConfig;
   const delay: number = settings.snifferTypeDelay;
 

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -170,7 +170,11 @@ const validate = async (document: TextDocument) => {
     args: commandArgs,
   };
 
-  addWindowsEnoentError(sniffer, originalCommand, 'spawn');
+  // Only needed when CMD is in the loop (shell: true) — CMD swallows ENOENT
+  // and exits 1. cross-spawn emits a real ENOENT 'error' event on its own.
+  if (runThroughShell) {
+    addWindowsEnoentError(sniffer, originalCommand, 'spawn');
+  }
 
   if (sniffer.stdin) {
     if (!useFilepath) {

--- a/src/test/resolvers/docker-path-resolver.spec.ts
+++ b/src/test/resolvers/docker-path-resolver.spec.ts
@@ -1,0 +1,145 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import {
+  toContainerPath,
+  toHostPath,
+} from '../../resolvers/docker-path-resolver';
+
+suite('Docker Path Resolver Test Suite', () => {
+  let platformStub: sinon.SinonStub;
+
+  teardown(() => {
+    platformStub?.restore();
+  });
+
+  const stubPlatform = (value: NodeJS.Platform) => {
+    platformStub = sinon.stub(process, 'platform').value(value);
+  };
+
+  test('Linux host -> Linux container', () => {
+    stubPlatform('linux');
+    const result = toContainerPath(
+      '/home/me/proj/src/Foo.php',
+      '/home/me/proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/var/www/proj/src/Foo.php');
+  });
+
+  test('Linux host -> Linux container, trailing slash on roots is tolerated', () => {
+    stubPlatform('linux');
+    const result = toContainerPath(
+      '/home/me/proj/src/Foo.php',
+      '/home/me/proj/',
+      '/var/www/proj/',
+    );
+    assert.strictEqual(result, '/var/www/proj/src/Foo.php');
+  });
+
+  test('Windows host -> Linux container', () => {
+    stubPlatform('win32');
+    const result = toContainerPath(
+      'C:\\Users\\me\\proj\\src\\Foo.php',
+      'C:\\Users\\me\\proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/var/www/proj/src/Foo.php');
+  });
+
+  test('Windows host -> Linux container, drive-letter case differs', () => {
+    stubPlatform('win32');
+    const result = toContainerPath(
+      'c:\\Users\\me\\proj\\src\\Foo.php',
+      'C:\\Users\\me\\proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/var/www/proj/src/Foo.php');
+  });
+
+  test('toContainerPath returns input unchanged when outside the workspace', () => {
+    stubPlatform('linux');
+    const result = toContainerPath(
+      '/elsewhere/Foo.php',
+      '/home/me/proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/elsewhere/Foo.php');
+  });
+
+  test('toContainerPath does not match a non-segment-boundary prefix', () => {
+    stubPlatform('linux');
+    // /home/me/proj is the workspace; /home/me/proj2 must not be remapped.
+    const result = toContainerPath(
+      '/home/me/proj2/src/Foo.php',
+      '/home/me/proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/home/me/proj2/src/Foo.php');
+  });
+
+  test('toContainerPath returns input unchanged when a root is empty', () => {
+    stubPlatform('linux');
+    assert.strictEqual(
+      toContainerPath('/a/b', '', '/var/www'),
+      '/a/b',
+      'host workspace root empty',
+    );
+    assert.strictEqual(
+      toContainerPath('/a/b', '/a', ''),
+      '/a/b',
+      'container workspace root empty',
+    );
+  });
+
+  test('toHostPath remaps container path back to Linux host', () => {
+    stubPlatform('linux');
+    const result = toHostPath(
+      '/var/www/proj/src/Foo.php',
+      '/home/me/proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, '/home/me/proj/src/Foo.php');
+  });
+
+  test('toHostPath remaps container path back to Windows host', () => {
+    stubPlatform('win32');
+    const result = toHostPath(
+      '/var/www/proj/src/Foo.php',
+      'C:\\Users\\me\\proj',
+      '/var/www/proj',
+    );
+    assert.strictEqual(result, 'C:\\Users\\me\\proj\\src\\Foo.php');
+  });
+
+  test('toHostPath returns input unchanged when outside the container workspace', () => {
+    stubPlatform('linux');
+    const result = toHostPath('/etc/passwd', '/home/me/proj', '/var/www/proj');
+    assert.strictEqual(result, '/etc/passwd');
+  });
+
+  test('round-trip on Linux: host -> container -> host', () => {
+    stubPlatform('linux');
+    const hostRoot = '/home/me/proj';
+    const containerRoot = '/var/www/proj';
+    const start = '/home/me/proj/src/Foo.php';
+    const round = toHostPath(
+      toContainerPath(start, hostRoot, containerRoot),
+      hostRoot,
+      containerRoot,
+    );
+    assert.strictEqual(round, start);
+  });
+
+  test('round-trip on Windows: host -> container -> host', () => {
+    stubPlatform('win32');
+    const hostRoot = 'C:\\Users\\me\\proj';
+    const containerRoot = '/var/www/proj';
+    const start = 'C:\\Users\\me\\proj\\src\\Foo.php';
+    const round = toHostPath(
+      toContainerPath(start, hostRoot, containerRoot),
+      hostRoot,
+      containerRoot,
+    );
+    assert.strictEqual(round, start);
+  });
+});

--- a/src/utils/docker-standard.ts
+++ b/src/utils/docker-standard.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { ResourceSettings } from '../interfaces/resource-settings';
+import { toContainerPath } from '../resolvers/docker-path-resolver';
+
+const hasPathSyntax = (standard: string): boolean => {
+  return (
+    standard.startsWith('/') ||
+    standard.startsWith('\\') ||
+    standard.startsWith('.') ||
+    standard.includes('/') ||
+    standard.includes('\\') ||
+    /^[a-zA-Z]:[\\/]/.test(standard)
+  );
+};
+
+const isReadableFile = async (filePath: string): Promise<boolean> => {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+};
+
+const isBareRulesetFile = (
+  standard: string,
+  allowedRulesets: string[],
+): boolean =>
+  allowedRulesets.includes(standard) ||
+  /^[a-zA-Z0-9._ -]+\.xml(\.dist)?$/i.test(standard);
+
+const resolveHostStandardPath = async (
+  standard: string,
+  resourceConf: ResourceSettings,
+): Promise<string | null> => {
+  const workspaceRoot = resourceConf.workspaceRoot;
+  if (!workspaceRoot) {
+    return null;
+  }
+
+  if (path.isAbsolute(standard) || /^[a-zA-Z]:[\\/]/.test(standard)) {
+    return standard;
+  }
+
+  if (hasPathSyntax(standard)) {
+    return path.join(workspaceRoot, standard);
+  }
+
+  if (!isBareRulesetFile(standard, resourceConf.allowedAutoRulesets)) {
+    return null;
+  }
+
+  const relativeRuleset = path.join(workspaceRoot, standard);
+  return (await isReadableFile(relativeRuleset)) ? relativeRuleset : null;
+};
+
+/**
+ * Convert a coding standard path to the equivalent container path.
+ *
+ * Simple standard names such as `PSR12` and `WordPress-Core` are left alone.
+ * Path-like values are resolved against the workspace when needed. Bare values
+ * such as `phpcs.xml` are mapped only when the file exists in the workspace.
+ */
+export const remapStandardForContainer = async (
+  standard: string,
+  resourceConf: ResourceSettings,
+): Promise<string> => {
+  if (!standard || !resourceConf.workspaceRoot) {
+    return standard;
+  }
+
+  const hostStandardPath = await resolveHostStandardPath(
+    standard,
+    resourceConf,
+  );
+
+  if (!hostStandardPath) {
+    return standard;
+  }
+
+  return toContainerPath(
+    hostStandardPath,
+    resourceConf.workspaceRoot,
+    resourceConf.dockerWorkspaceRoot,
+  );
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -34,10 +34,15 @@ export const getExtensionInfo = (): ExtensionInfo => {
 
 /**
  * Build the arguments needed to execute sniffer or fixer.
- * @param {string} filePath The file path to be linted or fixed. (Note: The path is obtained via vscode's API, so it's already normalized.)
+ * @param {string} filePath The file path to be linted or fixed. The caller is
+ *   responsible for translating to a container path when running in Docker mode.
  * @param {string} standard The coding standard to use.
  * @param {string[]} additionalArguments Any additional arguments to pass to the executable.
- * @param {string} toolType The type of tool being executed (e.g., 'sniffer', 'fixer').
+ * @param {string} toolType The type of tool being executed ('sniffer' or 'fixer').
+ * @param {boolean} useFilepath When `true`, pass `filePath` positionally and
+ *   skip stdin (`--stdin-path=` + `-`). Sniffer-only escape hatch for
+ *   container setups where stdin streaming misbehaves; the fixer must always
+ *   pass `false` because phpcbf in file mode does not return fixed content on stdout.
  * @returns {string[]} The array of arguments to pass to the sniffer or fixer executable.
  */
 export const getArgs = (
@@ -45,6 +50,7 @@ export const getArgs = (
   standard: string,
   additionalArguments: string[],
   toolType: 'sniffer' | 'fixer',
+  useFilepath: boolean = false,
 ): string[] => {
   let args = [];
 
@@ -61,8 +67,10 @@ export const getArgs = (
     args.push(`--standard=${standard}`);
   }
 
-  // Add the file path argument for stdin path resolution.
-  args.push(`--stdin-path=${filePath}`);
+  // In stdin mode, set --stdin-path so PHPCS resolves rules relative to the file.
+  if (!useFilepath) {
+    args.push(`--stdin-path=${filePath}`);
+  }
 
   // Validate additional arguments.
   additionalArguments = validateAdditionalArguments(additionalArguments);
@@ -70,9 +78,13 @@ export const getArgs = (
   // Append any additional arguments.
   args = args.concat(additionalArguments);
 
-  // Indicate we will be passing the file contents via stdin.
-  // This must be the last argument.
-  args.push('-');
+  if (useFilepath) {
+    // File mode: positional scan target must come after all options.
+    args.push(filePath);
+  } else {
+    // Stdin mode: file contents are piped via stdin; `-` must be the last argument.
+    args.push('-');
+  }
 
   return args;
 };


### PR DESCRIPTION
- Added phpcs v4 support (Influenced by https://github.com/mtbdata711/vscode-phpsab-docker)
- Added docker support

**Notes:**
`docker-standard.ts` is used only for the extension’s optional Docker mode.
It takes the resolved PHPCS/PHPCBF coding standard and, when that standard is a file/path, remaps it from the host workspace path to the container workspace path.
Example: `C:\repo\phpcs.xml` becomes `/app/phpcs.xml` before being passed as `--standard=/app/phpcs.xml`