### PR TITLE
add phpcs 4.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.0] - 2026-06-27
+
+### What's Changed
+
+* **PHP_CodeSniffer 4.x support** (backwards compatible with 3.x).
+  - Handle the new PHPCBF exit codes (`4` failure to fix some files / fixer conflict, `5` = `1 + 4`, `7` = `1 + 2 + 4`) so v4 runs no longer surface as failures.
+  - Treat exit code `2` correctly for both versions (3.x: some fixes failed; 4.x: non-auto-fixable issues remain) and still apply any valid fixed output returned alongside it.
+  - Replace the "4.x not supported" warning with version-mismatch detection only.
+  - Clarify 3.x vs 4.x stdout/stderr behaviour in the fixer and the exit-code labels.
+
+### Fixed
+
+* Fixer error handling for both v3 and v4 — only treat real failures as errors, stop swallowing diffs returned alongside non-zero exit codes, and no longer show an empty information message on error paths.
+
 ## [0.0.25] - 2026-05-09
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.0] - 2026-06-27
+
+### What's Changed
+
+* **PHP_CodeSniffer 4.x support** (backwards compatible with 3.x).
+  - Handle the new PHPCBF exit codes (`4` failure to fix some files / fixer conflict, `5` = `1 + 4`, `7` = `1 + 2 + 4`) so v4 runs no longer surface as failures.
+  - Treat exit code `2` correctly for both versions (3.x: some fixes failed; 4.x: non-auto-fixable issues remain) and still apply any valid fixed output returned alongside it.
+  - Replace the "4.x not supported" warning with version-mismatch detection only.
+  - Clarify 3.x vs 4.x stdout/stderr behaviour in the fixer and the exit-code labels.
+
+### Fixed
+
+* Fixer error handling for both v3 and v4 — only treat real failures as errors, stop swallowing diffs returned alongside non-zero exit codes, and no longer show an empty information message on error paths.
+
+
 ## [0.0.29] - 2026-09-09
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ This extension is available on both [VS Code Marketplace](https://marketplace.vi
 
 ## PHPCS Version Support
 
-This extension supports the [latest stable version of PHPCS 3.x](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/). If you are using an older version of PHPCS, please upgrade to the latest 3.x version.
+This extension supports both [PHP_CodeSniffer 3.x](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/) and 4.x. If you are using an older version of PHPCS, please upgrade to a supported 3.x or 4.x release.
 
-> **NOTE:** PHPCS 4.x is not currently supported.
->
-> As of v0.0.22, the extension will detect if PHPCS/PHPCBF version 4.x is being used and will display a warning message to the user. Some features may not work as expected when using version 4.x. Please consider downgrading to the latest 3.x version.
+> **NOTE:** As of v0.1.0, PHPCS 4.x is fully supported. The extension handles the new PHPCBF exit codes (`4`, `5`, `7`) and will only warn when the detected `phpcs`/`phpcbf` binaries are at mismatched major versions.
 
 ## Maintenance Status
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-phpsab",
   "displayName": "PHP Sniffer & Beautifier",
   "description": "PHP Sniffer & Beautifier for Visual Studio Code",
-  "version": "0.0.25",
+  "version": "0.1.0",
   "icon": "php_logo.png",
   "publisher": "valeryanm",
   "homepage": "https://github.com/valeryan/vscode-phpsab",
@@ -26,6 +26,8 @@
     "php",
     "phpcs",
     "phpcbf",
+    "phpcs4",
+    "php_codesniffer",
     "linter",
     "fixer"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-phpsab",
   "displayName": "PHP Sniffer & Beautifier",
   "description": "PHP Sniffer & Beautifier for Visual Studio Code",
-  "version": "0.0.29",
+  "version": "0.1.0",
   "icon": "php_logo.png",
   "publisher": "valeryanm",
   "homepage": "https://github.com/valeryan/vscode-phpsab",
@@ -26,6 +26,8 @@
     "php",
     "phpcs",
     "phpcbf",
+    "phpcs4",
+    "php_codesniffer",
     "linter",
     "fixer"
   ],

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -144,7 +144,9 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   const stdout = fixer.stdout.toString();
   const stderr = fixer.stderr.toString();
 
-  // Set the original command information (not parsed) for Windows ENOENT error handling
+  // Set the original (unquoted) command information for Windows ENOENT error handling. With shell: true,
+  // cmd.exe swallows a missing-executable ENOENT and exits 1 instead of surfacing it, so
+  // addWindowsEnoentError reconstructs it; on *nix Node already populates fixer.error directly.
   const originalCommand = {
     commandPath: CBFExecutable,
     args: lintArgs,
@@ -156,11 +158,9 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   logger.info(`FIXER EXIT CODE: ${exitcode}`);
 
-  // We only log STDOUT if it starts with ERROR (3.x versions of phpcbf output "ERROR"
-  // messages to stdout), as otherwise it could be the whole file contents,
-  // which clutters the log when debugging.
-  //
-  // This will be removed once we require phpcbf 4.x, which outputs errors to STDERR.
+  // PHPCS 3.x's phpcbf writes "ERROR" status lines to stdout mixed with the fixed file content; PHPCS 4.x
+  // writes errors to stderr instead. Log stdout only when it looks like a 3.x error line to avoid dumping
+  // fixed file content into the output channel.
   if (stdout && (stdout.startsWith('ERROR') || stdout.startsWith(getEOL()))) {
     logger.info(`FIXER STDOUT: ${stdout.trim()}`);
   }
@@ -171,12 +171,13 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   let fixed = stdout;
 
-  let errors: { [key: number]: string } = {
-    3: 'FIXER: A general script execution error occurred.',
-    16: 'FIXER: Configuration error of the application.',
-    32: 'FIXER: Configuration error of a Fixer.',
-    64: 'FIXER: Exception raised within the application.',
-    255: 'FIXER: A Fatal execution error occurred.',
+  // PHPCS-specific exit-code labels. (Earlier versions of this map used PHP-CS-Fixer
+  // labels by mistake - different tool, different codes.)
+  const errors: { [key: number]: string } = {
+    3: 'FIXER: Processing / script execution error (PHPCS 3.x).',
+    16: 'FIXER: Processing error — invalid CLI options or ruleset (PHPCS 4.x).',
+    64: 'FIXER: Requirements not met — PHP version or missing extensions (PHPCS 4.x).',
+    255: 'FIXER: A fatal execution error occurred.',
   };
 
   let error: string = '';
@@ -197,11 +198,22 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   }
 
   /**
-   * fixer exit codes:
-   * Exit code 0 is used to indicate that no fixable errors were found, so nothing was fixed
-   * Exit code 1 is used to indicate that all fixable errors were fixed correctly
-   * Exit code 2 is used to indicate that FIXER failed to fix some of the fixable errors it found
-   * Exit code 3 is used for general script execution errors
+   * PHPCBF exit codes:
+   *
+   * PHP_CodeSniffer 3.x:
+   * 0: no fixable errors were found, so nothing was fixed
+   * 1: all fixable errors were fixed correctly
+   * 2: PHPCBF failed to fix some of the fixable errors it found
+   * 3: processing / script execution error
+   *
+   * PHP_CodeSniffer 4.x:
+   * 0: clean / auto-fixed with no remaining issues
+   * 1: issues found/remaining, auto-fixable
+   * 2: issues found/remaining, non-auto-fixable
+   * 4: failure to fix some files / fixer conflict (phpcbf only)
+   * 5: 1 + 4 (phpcbf only)
+   * 7: 1 + 2 + 4 (phpcbf only)
+   * 16, 64: processing / requirements errors
    */
   switch (exitcode) {
     case null: {
@@ -240,56 +252,52 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
       break;
     }
-    case 2: {
-      // If stdout has valid fixed output (and doesn't contain error messages),
-      // then this exit code indicates that some fixable errors failed to be fixed.
+    // 2 has different meanings between versions:
+    //  - PHPCS 3.x phpcbf: some fixable errors failed to fix.
+    //  - PHPCS 4.x phpcbf (NON_FIXABLE): auto-fixable were fixed, but non-auto-fixable issues remain.
+    // 4 / 5 / 7 are PHPCS 4.x bitmask combinations involving FAILED_TO_FIX. In every case, stdout (when
+    // valid) contains the partially / fully fixed file and should be applied. The user-facing message is
+    // unified — neutral wording that's accurate for both versions.
+    case 2:
+    case 4:
+    case 5:
+    case 7: {
       if (hasValidFixedOutput(stdout, fileText)) {
         result = fixed;
-        message = 'FIXER failed to fix some of the fixable errors.';
-      }
-      // If Node errors.
-      else if (nodeError) {
-        // Destructure the returned object and assign to variables.
+        message =
+          'FIXER applied auto-fixes; some issues could not be auto-fixed.';
+      } else if (nodeError) {
         ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
         error += errorMsg;
+      } else {
+        // No fixes applied (e.g. PHPCS 4.x exit 2 with only non-fixable issues, or 3.x exit 2
+        // where every fix attempt failed). Inform without error.
+        message =
+          'No auto-fixable issues were applied; non-auto-fixable issues remain.';
       }
 
       break;
     }
     default:
-      // A PHPCBF error occurred.
+      // A PHPCBF error occurred. stdout has already been logged above; don't splat it into the user's error dialog.
       error =
         errors[exitcode] ||
         `FIXER: An unknown error occurred with exit code ${exitcode}.`;
-      if (fixed.length > 0) {
-        error += '\n' + fixed + '\n';
-      }
-      // Other errors.
-      else {
-        // If Node errors.
-        if (nodeError) {
-          // Destructure the returned object and assign to variables.
-          ({ errorMsg, extraLoggerMsg } = determineNodeError(
-            nodeError,
-            'fixer',
-          ));
-          error += errorMsg;
-        }
-        // If no specific error is found, return a generic fatal error.
-        else {
-          error += 'FATAL: Unknown error occurred.';
-        }
+      if (nodeError) {
+        ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
+        error += ` ${errorMsg}`;
       }
   }
 
   logger.endTimer('Fixer');
 
-  window.showInformationMessage(message);
-
   if (error !== '') {
     logger.error(`${error}${extraLoggerMsg}`);
     return Promise.reject(error);
-  } else {
+  }
+
+  if (message !== '') {
+    window.showInformationMessage(message);
     logger.info(`FIXER MESSAGE: ${message}`);
   }
 

--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -149,7 +149,9 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   const stdout = fixer.stdout.toString();
   const stderr = fixer.stderr.toString();
 
-  // Set the original command information (not parsed) for Windows ENOENT error handling
+  // Set the original (unquoted) command information for Windows ENOENT error handling. With shell: true,
+  // cmd.exe swallows a missing-executable ENOENT and exits 1 instead of surfacing it, so
+  // addWindowsEnoentError reconstructs it; on *nix Node already populates fixer.error directly.
   const originalCommand: OriginalCommand = {
     commandPath: CBFExecutable,
     args: lintArgs,
@@ -161,11 +163,9 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   logger.info(`FIXER EXIT CODE: ${exitcode}`);
 
-  // We only log STDOUT if it starts with ERROR (3.x versions of phpcbf output "ERROR"
-  // messages to stdout), as otherwise it could be the whole file contents,
-  // which clutters the log when debugging.
-  //
-  // This will be removed once we require phpcbf 4.x, which outputs errors to STDERR.
+  // PHPCS 3.x's phpcbf writes "ERROR" status lines to stdout mixed with the fixed file content; PHPCS 4.x
+  // writes errors to stderr instead. Log stdout only when it looks like a 3.x error line to avoid dumping
+  // fixed file content into the output channel.
   if (stdout && (stdout.startsWith('ERROR') || stdout.startsWith(getEOL()))) {
     logger.info(`FIXER STDOUT: ${stdout.trim()}`);
   }
@@ -176,12 +176,13 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
   let fixed = stdout;
 
-  let errors: { [key: number]: string } = {
-    3: 'FIXER: A general script execution error occurred.',
-    16: 'FIXER: Configuration error of the application.',
-    32: 'FIXER: Configuration error of a Fixer.',
-    64: 'FIXER: Exception raised within the application.',
-    255: 'FIXER: A Fatal execution error occurred.',
+  // PHPCS-specific exit-code labels. (Earlier versions of this map used PHP-CS-Fixer
+  // labels by mistake - different tool, different codes.)
+  const errors: { [key: number]: string } = {
+    3: 'FIXER: Processing / script execution error (PHPCS 3.x).',
+    16: 'FIXER: Processing error — invalid CLI options or ruleset (PHPCS 4.x).',
+    64: 'FIXER: Requirements not met — PHP version or missing extensions (PHPCS 4.x).',
+    255: 'FIXER: A fatal execution error occurred.',
   };
 
   let error: string = '';
@@ -202,11 +203,22 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
   }
 
   /**
-   * fixer exit codes:
-   * Exit code 0 is used to indicate that no fixable errors were found, so nothing was fixed
-   * Exit code 1 is used to indicate that all fixable errors were fixed correctly
-   * Exit code 2 is used to indicate that FIXER failed to fix some of the fixable errors it found
-   * Exit code 3 is used for general script execution errors
+   * PHPCBF exit codes:
+   *
+   * PHP_CodeSniffer 3.x:
+   * 0: no fixable errors were found, so nothing was fixed
+   * 1: all fixable errors were fixed correctly
+   * 2: PHPCBF failed to fix some of the fixable errors it found
+   * 3: processing / script execution error
+   *
+   * PHP_CodeSniffer 4.x:
+   * 0: clean / auto-fixed with no remaining issues
+   * 1: issues found/remaining, auto-fixable
+   * 2: issues found/remaining, non-auto-fixable
+   * 4: failure to fix some files / fixer conflict (phpcbf only)
+   * 5: 1 + 4 (phpcbf only)
+   * 7: 1 + 2 + 4 (phpcbf only)
+   * 16, 64: processing / requirements errors
    */
   switch (exitcode) {
     case null: {
@@ -245,56 +257,52 @@ const format = async (document: TextDocument, fullDocument: boolean) => {
 
       break;
     }
-    case 2: {
-      // If stdout has valid fixed output (and doesn't contain error messages),
-      // then this exit code indicates that some fixable errors failed to be fixed.
+    // 2 has different meanings between versions:
+    //  - PHPCS 3.x phpcbf: some fixable errors failed to fix.
+    //  - PHPCS 4.x phpcbf (NON_FIXABLE): auto-fixable were fixed, but non-auto-fixable issues remain.
+    // 4 / 5 / 7 are PHPCS 4.x bitmask combinations involving FAILED_TO_FIX. In every case, stdout (when
+    // valid) contains the partially / fully fixed file and should be applied. The user-facing message is
+    // unified — neutral wording that's accurate for both versions.
+    case 2:
+    case 4:
+    case 5:
+    case 7: {
       if (hasValidFixedOutput(stdout, fileText)) {
         result = fixed;
-        message = 'FIXER failed to fix some of the fixable errors.';
-      }
-      // If Node errors.
-      else if (nodeError) {
-        // Destructure the returned object and assign to variables.
+        message =
+          'FIXER applied auto-fixes; some issues could not be auto-fixed.';
+      } else if (nodeError) {
         ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
         error += errorMsg;
+      } else {
+        // No fixes applied (e.g. PHPCS 4.x exit 2 with only non-fixable issues, or 3.x exit 2
+        // where every fix attempt failed). Inform without error.
+        message =
+          'No auto-fixable issues were applied; non-auto-fixable issues remain.';
       }
 
       break;
     }
     default:
-      // A PHPCBF error occurred.
+      // A PHPCBF error occurred. stdout has already been logged above; don't splat it into the user's error dialog.
       error =
         errors[exitcode] ||
         `FIXER: An unknown error occurred with exit code ${exitcode}.`;
-      if (fixed.length > 0) {
-        error += '\n' + fixed + '\n';
-      }
-      // Other errors.
-      else {
-        // If Node errors.
-        if (nodeError) {
-          // Destructure the returned object and assign to variables.
-          ({ errorMsg, extraLoggerMsg } = determineNodeError(
-            nodeError,
-            'fixer',
-          ));
-          error += errorMsg;
-        }
-        // If no specific error is found, return a generic fatal error.
-        else {
-          error += 'FATAL: Unknown error occurred.';
-        }
+      if (nodeError) {
+        ({ errorMsg, extraLoggerMsg } = determineNodeError(nodeError, 'fixer'));
+        error += ` ${errorMsg}`;
       }
   }
 
   logger.endTimer('Fixer');
 
-  window.showInformationMessage(message);
-
   if (error !== '') {
     logger.error(`${error}${extraLoggerMsg}`);
     return Promise.reject(error);
-  } else {
+  }
+
+  if (message !== '') {
+    window.showInformationMessage(message);
     logger.info(`FIXER MESSAGE: ${message}`);
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -274,7 +274,7 @@ const getSettings = async (
 };
 
 /**
- * Check PHPCS version compatibility and warn on 4.x versions.
+ * Check PHPCS version compatibility.
  * @param {Settings} settings The extension settings
  * @return {Promise<void>}
  */
@@ -324,14 +324,6 @@ const checkPhpcsVersionCompatibility = async (
     // Check for version mismatches when both versions are available
     else if (phpcsVersion && phpcbfVersion && phpcsVersion !== phpcbfVersion) {
       warningMsg = `Version mismatch detected: PHPCS version ${phpcsVersion} and PHPCBF version ${phpcbfVersion} from "${resourceRoot}". This may lead to unexpected behavior. Please ensure both are from the same installation directory.`;
-    }
-    // Check for unsupported 4.x versions
-    else if (
-      (phpcsVersion && phpcsVersion.startsWith('4.')) ||
-      (phpcbfVersion && phpcbfVersion.startsWith('4.'))
-    ) {
-      const version = phpcsVersion || phpcbfVersion;
-      warningMsg = `Version ${version} detected in "${resourceRoot}". Version 4.x is not supported yet. Some features may not work as expected. Please consider downgrading to the latest 3.x version.`;
     }
 
     // Only show warning if there's a message to display.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -284,7 +284,7 @@ const getSettings = async (
 };
 
 /**
- * Check PHPCS version compatibility and warn on 4.x versions.
+ * Check PHPCS version compatibility.
  * @param {Settings} settings The extension settings
  * @return {Promise<void>}
  */
@@ -334,14 +334,6 @@ const checkPhpcsVersionCompatibility = async (
     // Check for version mismatches when both versions are available
     else if (phpcsVersion && phpcbfVersion && phpcsVersion !== phpcbfVersion) {
       warningMsg = `Version mismatch detected: PHPCS version ${phpcsVersion} and PHPCBF version ${phpcbfVersion} from "${resourceRoot}". This may lead to unexpected behavior. Please ensure both are from the same installation directory.`;
-    }
-    // Check for unsupported 4.x versions
-    else if (
-      (phpcsVersion && phpcsVersion.startsWith('4.')) ||
-      (phpcbfVersion && phpcbfVersion.startsWith('4.'))
-    ) {
-      const version = phpcsVersion || phpcbfVersion;
-      warningMsg = `Version ${version} detected in "${resourceRoot}". Version 4.x is not supported yet. Some features may not work as expected. Please consider downgrading to the latest 3.x version.`;
     }
 
     // Only show warning if there's a message to display.


### PR DESCRIPTION
close https://github.com/valeryan/vscode-phpsab/issues/168

Added phpcs v4 support with as minimal changes as possible.

# Test Results — vscode-phpsab

Integration verification of the `phpcs-4-support` branch against **PHP_CodeSniffer 3.x and 4.x**.

| | |
|---|---|
| **Date** | 2026-09-11 |
| **Platform** | Windows 11, PHP 8.1.32 (cli) |
| **VS Code** | 1.137.0 (real Extension Development Host) |
| **PHPCS 3.x** | 3.13.6 (stable) |
| **PHPCS 4.x** | 4.0.4 (stable) |
| **Result** | **28/28 passing** — 14/14 on v3, 14/14 on v4 |

---

## Tests

### activation, sniffer, fixer

| | Test | v3 | v4 |
|---|---|:--:|:--:|
| 1 | extension activates | ✔ | ✔ |
| 2 | no competing PHP extensions are active | ✔ | ✔ |
| 3 | registers the `fixer.fix` command | ✔ | ✔ |
| 4 | sniffer reports phpcs diagnostics for a non-compliant file | ✔ | ✔ |
| 5 | sniffer reports no diagnostics for a compliant file | ✔ | ✔ |
| 6 | fixer applies PSR12 fixes to a fixable file | ✔ | ✔ |
| 7 | fixer leaves an already-clean file unchanged | ✔ | ✔ |
| 8 | fixer handles a file whose issues are not auto-fixable | ✔ | ✔ |
| 9 | fixer applies partial fixes to a mixed file and keeps non-fixable issues | ✔ | ✔ |

### error branches

| | Test | v3 | v4 |
|---|---|:--:|:--:|
| 10 | nonexistent phpcbf path does not corrupt the document | ✔ | ✔ |
| 11 | invalid coding standard surfaces an error without writing it to the file | ✔ | ✔ |
| 12 | malformed ruleset surfaces an error without writing it to the file | ✔ | ✔ |
| 13 | sniffer tolerates a nonexistent phpcs path without stale diagnostics | ✔ | ✔ |
| 14 | extension still works after an error (recovery) | ✔ | ✔ |
| 15 | a clean file is never modified regardless of exit-code semantics | ✔ | ✔ |

**Totals:** 15 ✔ / 0 ✗ on v3 · 15 ✔ / 0 ✗ on v4

---

## Exit-code verification

`phpcbf`, stdin mode, PSR12 ruleset. Measured directly from both binaries, then
confirmed against the branch logic in [fixer.ts](../src/fixer.ts).

| Case | 3.13.6 | 4.0.4 | Branch taken | Document written? |
|---|---|---|---|---|
| Clean file | `1` — stdout identical to input | `0` | NOOP — "No fixable errors were found." | No |
| Fixable file (all fixable) | `1` | `0` | APPLY — "All fixable errors were fixed correctly." | Yes (fixed code) |
| **Mixed** (some fixable, some not) | `1` | `2` | APPLY — v3: "All fixable errors were fixed correctly." · v4: "FIXER applied auto-fixes; some issues could not be auto-fixed." | **Yes (partial fix)** |
| Only non-fixable issues | `1` | `2` | NOOP — issues remain | No |
| Unknown standard | `3` — error on **stdout** | `16` — error on **stderr** | ERROR | No |
| Missing ruleset file | `3` — stdout | `16` — stderr | ERROR | No |
| Invalid CLI option | `3` — stdout | `16` — stderr | ERROR | No |

Every exit code routes to the correct branch on both versions, and **phpcbf error
text is never written into the user's document**.

### Three findings worth keeping

**The 3.x clean-file trap.** On 3.13.6 a *clean* file returns exit **`1`**, which the
exit-code switch alone reads as "all fixable errors were fixed". What prevents a
pointless rewrite is `hasValidFixedOutput()`, which additionally requires
`stdout !== originalFileText`. That guard is load-bearing — don't simplify it away.

**The mixed case is where the majors diverge most.** A file with *both* fixable and
non-fixable violations returns exit **`1`** on 3.x but exit **`2`** on 4.x — yet both
produce identical partially-fixed output that **must** be written to the file. This is
precisely why the branch added `4`, `5`, `7` to the `case 2` arm: on `main` those 4.x
bitmask codes fell through to `default` and were reported as errors, discarding a valid
fix. Note that exit `2` alone does **not** mean "don't write" — `hasValidFixedOutput()`
decides that, not the exit code.

**stdout vs stderr diverges between majors.** 3.x writes error banners to **stdout**
(prefixed `ERROR:`); 4.x writes them to **stderr** and leaves stdout empty. This is
why `fixer.ts` only logs stdout when it looks like a 3.x error line — otherwise it
would dump fixed file content into the output channel.

### Known cosmetic inaccuracy (not a correctness bug)

On **3.x only**, the user-facing message can understate what happened, because exit `1`
means "all fixable errors were fixed" regardless of what else remains:

- a file with **only non-fixable** issues reports *"No fixable errors were found."*
  (exit `1` with unchanged stdout is indistinguishable from a clean file without
  parsing the report);
- a **mixed** file reports *"All fixable errors were fixed correctly."* without
  mentioning the issues that could not be fixed.

In both cases the file content is handled correctly — only the wording is imprecise.
4.x distinguishes these accurately via exit `2` and gets the more precise message
*"FIXER applied auto-fixes; some issues could not be auto-fixed."*
