### PR TITLE
docs: add a note that specifying multiple standards is supported.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,28 +1,29 @@
 # vscode-phpcbf
 
-![Current Version](https://img.shields.io/visual-studio-marketplace/v/ValeryanM.vscode-phpsab)
-![Installs](https://img.shields.io/visual-studio-marketplace/i/ValeryanM.vscode-phpsab)
+![Current Version](https://img.shields.io/open-vsx/v/ValeryanM/vscode-phpsab?label=version)
+![VS Marketplace Installs](https://img.shields.io/badge/VS_Marketplace_Installs-~300k-brightgreen)
+![Open VSX Registry Installs](https://img.shields.io/open-vsx/dt/ValeryanM/vscode-phpsab?label=VSX%20Installs)
 ![GitHub issues](https://img.shields.io/github/issues-raw/valeryan/vscode-phpsab)
 
-Integrates [phpcs & phpcbf](https://github.com/squizlabs/PHP_CodeSniffer.git) into [Visual Studio Code](https://code.visualstudio.com/).
+Integrates [phpcs & phpcbf](https://github.com/squizlabs/PHP_CodeSniffer.git) into [Visual Studio Code (VS Code)](https://code.visualstudio.com/).
 
 This extension is designed to use an auto config search functionality. When it finds a configuration file through auto search this extension should use that configuration file to create reports with phpcs and apply fixes with phpcbf based on the same configuration.
 
 ## Setup Development Version
 
-- install the [Visual Studio Code](https://code.visualstudio.com/) [npm extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
-- install the VS Code [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (for linting and auto-fixing code)
-- clone this repository and checkout `develop` branch
-- open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
-- run VS Code task `npm install`
+- Install the VS Code [npm extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
+- Install the VS Code [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (for linting and auto-fixing code)
+- Clone this repository and checkout `develop` branch
+- Open the cloned repository folder using VS Code
+- Install the dependencies using `npm install`
 
 ## Run/Debug Development Version
 
 To run the development version of the `vscode-phpsab` extension:
 
-- open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
-- select sidebar option `Debug`
-- press `Start Debugging` button or hit F5
+- Open the cloned repository folder using VS Code
+- Select sidebar option `Debug`
+- Press `Start Debugging` button or hit <kbd>F5</kbd>
 
 This will launch a new VS Code window named `Extension Development Host`, automatically using the development version of the `vscode-phpsab` extension.
 
@@ -38,4 +39,4 @@ To install a development version of this extension for testing you will need to 
 
 ## Publishing Releases
 
-Using the Release system on Github, draft a new release with the desired version tag. The github workflow should handle updating the package.json version and publishing the release to both Vs Marketplace and the Open VSX Registry. These both require a PAT to be set in the security section on github.com and will occasionally need to be updated or rotated if the publishing workflow fails.
+Using the Release system on Github, draft a new release with the desired version tag. The github workflow should handle updating the package.json version and the changelog. It will then publish the release to both VS Marketplace and the Open VSX Registry. These both require a PAT to be set in the security section on github.com and will occasionally need to be updated or rotated if the publishing workflow fails.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,19 +10,19 @@ This extension is designed to use an auto config search functionality. When it f
 
 ## Setup Development Version
 
--   install the [Visual Studio Code](https://code.visualstudio.com/) [npm extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
--   install the VS Code [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (for linting and auto-fixing code)
--   clone this repository and checkout `develop` branch
--   open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
--   run VS Code task `npm install`
+- install the [Visual Studio Code](https://code.visualstudio.com/) [npm extension](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script)
+- install the VS Code [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (for linting and auto-fixing code)
+- clone this repository and checkout `develop` branch
+- open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
+- run VS Code task `npm install`
 
 ## Run/Debug Development Version
 
 To run the development version of the `vscode-phpsab` extension:
 
--   open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
--   select sidebar option `Debug`
--   press `Start Debugging` button or hit F5
+- open the cloned repository folder using [Visual Studio Code](https://code.visualstudio.com/)
+- select sidebar option `Debug`
+- press `Start Debugging` button or hit F5
 
 This will launch a new VS Code window named `Extension Development Host`, automatically using the development version of the `vscode-phpsab` extension.
 
@@ -30,11 +30,11 @@ This will launch a new VS Code window named `Extension Development Host`, automa
 
 To install a development version of this extension for testing you will need to install the vsce package and package the project into a `.vsix` file.
 
--   Install vsce: `npm install -g @vscode/vsce`
--   In the root of the project run: `vsce package`
--   From the VSCode main menu, select "Extensions", click the `...` on the Extensions tab.
--   Find the option that is `Install from VSIX...` and follow the prompts.
--   After installing, you may need to reload VSCode.
+- Install vsce: `npm install -g @vscode/vsce`
+- In the root of the project run: `vsce package`
+- From the VSCode main menu, select "Extensions", click the `...` on the Extensions tab.
+- Find the option that is `Install from VSIX...` and follow the prompts.
+- After installing, you may need to reload VSCode.
 
 ## Publishing Releases
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,11 @@ If omitted, the plugin will try to locate `phpcs` using you local composer.json,
 C:\\Users\\enter-your-username-here\\AppData\\Roaming\\Composer\\vendor\\bin\\phpcs.bat
 ```
 
-> **NOTE:** A leading `~` is expanded to your home directory, e.g. `~/.composer/vendor/bin/phpcs`.
+> **NOTE:** A leading `~` is automatically expanded to your home directory.
+
+```
+~/.composer/vendor/bin/phpcs
+```
 
 ### **phpsab.executablePathCBF**
 
@@ -279,7 +283,11 @@ If omitted, the extension will try to locate `phpcbf` using you local composer.j
 C:\\Users\\enter-your-username-here\\AppData\\Roaming\\Composer\\vendor\\bin\\phpcbf.bat
 ```
 
-> **NOTE:** A leading `~` is expanded to your home directory, e.g. `~/.composer/vendor/bin/phpcbf`.
+> **NOTE:** A leading `~` is automatically expanded to your home directory.
+
+```
+~/.composer/vendor/bin/phpcbf
+```
 
 ### **phpsab.standard**
 
@@ -287,7 +295,7 @@ C:\\Users\\enter-your-username-here\\AppData\\Roaming\\Composer\\vendor\\bin\\ph
 
 This setting controls the coding standard used by `phpcs` and `phpcbf`. You may specify the name, absolute path or workspace relative path of the coding standard to use; and also multiple standards separated by commas (as supported by PHPCS), eg. `"PSR2,WordPress,/path/to/project/phpcs.xml"`.
 
-> **NOTE:** While using composer dependency manager over global installation make sure you use the phpcbf commands under your project scope !
+> **NOTE:** While using composer dependency manager over global installation make sure you use the phpcbf commands under your project scope!
 
 The following values are applicable:
 
@@ -355,7 +363,7 @@ The following values are applicable:
     }
     ```
 
-    A leading `~` is also expanded to your home directory:
+    A leading `~` will be expanded to your home directory:
 
     ```json
     {
@@ -437,7 +445,13 @@ By default, the icons will be shown, but can be disabled by setting this option 
 
 [ *Scope:* Resource | Optional | *Type:* string | *Default:* composer.json ]
 
-This setting allows you to override the path to your composer.json file when it does not reside at the workspace root. You may specify the absolute path or workspace relative path to the `composer.json` file. A leading `~` is expanded to your home directory, e.g. `~/projects/my-app/composer.json`.
+This setting allows you to override the path to your composer.json file when it does not reside at the workspace root. You may specify the absolute path or workspace relative path to the `composer.json` file. A leading `~` is automatically expanded to your home directory.
+
+```json
+{
+    "phpsab.composerJsonPath": "~/projects/my-app/composer.json"
+}
+```
 
 ### **phpsab.phpExecutablePath**
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ C:\\Users\\enter-your-username-here\\AppData\\Roaming\\Composer\\vendor\\bin\\ph
 
 [ *Scope:* Resource | Optional | *Type:* string | *Default:* null ]
 
-This setting controls the coding standard used by `phpcs` and `phpcbf`. You may specify the name, absolute path or workspace relative path of the coding standard to use.
+This setting controls the coding standard used by `phpcs` and `phpcbf`. You may specify the name, absolute path or workspace relative path of the coding standard to use; and also multiple standards separated by commas (as supported by PHPCS), eg. `"PSR2,WordPress,/path/to/project/phpcs.xml"`.
 
 > **NOTE:** While using composer dependency manager over global installation make sure you use the phpcbf commands under your project scope !
 
@@ -439,7 +439,7 @@ The order of precedence for finding PHP path in the settings is as follows:
 2. Devsense's "PHP Tools" extension setting `php.executablePath`.
 3. This extension's `phpsab.phpExecutablePath` setting.
 
-The path should lead to the directory where the executable can be found, abd shouldn't include the actual executable itself.
+The path should lead to the directory where the executable can be found, and shouldn't include the actual executable itself.
 
 On Windows, if it detects the path has `php.exe` at the end, then it will be removed from the path. On other systems, it won't detect or remove anything.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ When in single file mode:
 
 A global composer setup is required:
 
-- The `phpsab.executablePathCS` and `phpsab.executablePathCBF` settings **must** be set to the full absolute path of phpcs and phpcbf respectively, _OR_ set them to empty strings to allow the extension to automatically find the global composer installation and resolve the paths to the globally installed phpcs/phpcbf.
+- The `phpsab.executablePathCS` and `phpsab.executablePathCBF` settings **must** be set to the full absolute path of phpcs and phpcbf respectively, *OR* set them to empty strings to allow the extension to automatically find the global composer installation and resolve the paths to the globally installed phpcs/phpcbf.
 
 - If the `phpsab.standard` setting is used for a ruleset file then it **must** be the full absolute path.
 
@@ -123,20 +123,20 @@ Once phpcs is installed, you can proceed to install the vscode-phpsab plugin if 
 The `phpcs` linter can be installed globally using the Composer Dependency Manager for PHP.
 
 1. Install [composer](https://getcomposer.org/doc/00-intro.md).
-1. Require `phpcs` package by typing the following in a terminal:
+2. Require `phpcs` package by typing the following in a terminal:
 
     ```bash
     composer global require squizlabs/php_codesniffer
     ```
 
-1. You must specifically add the phpcs and phpcbf that you want to used to the global PATH on your system for the extension to auto detect them or set the executablePath for phpcs and phpcbf manually.
+3. You must specifically add the phpcs and phpcbf that you want to used to the global PATH on your system for the extension to auto detect them or set the executablePath for phpcs and phpcbf manually.
 
 ### Project-wide Installation
 
 The `phpcs` linter can be installed in your project using the Composer Dependency Manager for PHP.
 
 1. Install [composer](https://getcomposer.org/doc/00-intro.md).
-1. Require `phpcs` package by typing the following at the root of your project in a terminal:
+2. Require `phpcs` package by typing the following at the root of your project in a terminal:
 
     ```bash
     composer require --dev squizlabs/php_codesniffer
@@ -145,10 +145,10 @@ The `phpcs` linter can be installed in your project using the Composer Dependenc
 ### Plugin Installation
 
 1. Open Visual Studio Code.
-1. Press <kbd>Ctrl + P</kbd> on Windows or <kbd>Cmd + P</kbd> on Mac to open the Quick Open dialog.
-1. Type `ext install phpsab` to find the extension.
-1. Press <kbd>Enter</kbd> or click the cloud icon to install it.
-1. Restart Visual Studio Code!
+2. Press <kbd>Ctrl + P</kbd> on Windows or <kbd>Cmd + P</kbd> on Mac to open the Quick Open dialog.
+3. Type `ext install phpsab` to find the extension.
+4. Press <kbd>Enter</kbd> or click the cloud icon to install it.
+5. Restart Visual Studio Code!
 
 This extension is available on both [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ValeryanM.vscode-phpsab) and [Open VSX Registry](https://open-vsx.org/extension/ValeryanM/vscode-phpsab).
 
@@ -169,7 +169,7 @@ This setting controls whether `phpcbf` fixer is enabled.
 
 ### **phpsab.fixerArguments**
 
-[ _Scope:_ Resource | Optional | _Type:_ string[] | _Default:_ [] ]
+[ *Scope:* Resource | Optional | *Type:* string[] | *Default:* [] ]
 
 Passes additional arguments to `phpcbf` runner.
 
@@ -188,7 +188,7 @@ Passes additional arguments to `phpcbf` runner.
 
 > **NOTE:** All arguments passed will be surrounded in double quotes automatically.
 
-_Example_
+*Example*
 
 ```bash
 {
@@ -207,7 +207,7 @@ This setting controls whether `phpcs` sniffer is enabled.
 
 ### **phpsab.snifferArguments**
 
-[ _Scope:_ Resource | Optional | _Type:_ string[] | _Default:_ [] ]
+[ *Scope:* Resource | Optional | *Type:* string[] | *Default:* [] ]
 
 Passes additional arguments to `phpcs` runner.
 
@@ -226,7 +226,7 @@ Passes additional arguments to `phpcs` runner.
 
 > **NOTE:** All arguments passed will be surrounded in double quotes automatically.
 
-_Example_
+*Example*
 
 ```bash
 {
@@ -397,7 +397,7 @@ Automatically search for any `.phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml`, `phpc
 
 ### **phpsab.allowedAutoRulesets**
 
-[ _Scope:_ Resource | Optional | _Type:_ array | _Default:_ [] ]
+[ *Scope:* Resource | Optional | *Type:* array | *Default:* [] ]
 
 An array of filenames that could contain a valid phpcs ruleset.
 
@@ -415,7 +415,7 @@ Enum dropdown options to set Sniffer Mode to `onSave` or `onType`.
 
 1. `onSave`: The Sniffer will only update diagnostics when the document is saved.
 
-1. `onType`: The Sniffer will update diagnostics as you type in a document.
+2. `onType`: The Sniffer will update diagnostics as you type in a document.
 
 ### **phpsab.snifferTypeDelay**
 
@@ -491,7 +491,7 @@ Good Example:
 
 ### **phpsab.excludeGlobs**
 
-[ _Scope:_ Resource | Optional | _Type:_ array | _Default:_ [
+[ *Scope:* Resource | Optional | *Type:* array | *Default:* [
 "\*\*/vendor/\*\*",
 "\*\*/node_modules/\*\*"
 ] ]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In January 2024 [seebeen](https://github.com/seebeen) signed on to be a maintain
 
 ## Installation
 
-Visual Studio Code must be installed in order to use this plugin. If Visual Studio Code is not installed, please follow the instructions [here](https://code.visualstudio.com/Docs/editor/setup).
+Visual Studio Code (VS Code) must be installed in order to use this plugin. If VS Code is not installed, please follow [VS Code's instructions](https://code.visualstudio.com/Docs/editor/setup).
 
 ## Usage
 


### PR DESCRIPTION
This pull request focuses on improving the documentation. The changes include updates to retired badges, enhanced formatting, and clarification of configuration options.

**Documentation improvements:**

* Updated badges in `DEVELOPMENT.md` to replace the retired badges, which were previously updated in `README.md` in #209.

* Auto-formatting in both `DEVELOPMENT.md` and `README.md` using the new eslint markdown rules, including improved step numbering, and consistent use of asterisk-style italics.

* Clarified the use of the tilde (`~`) for home directory paths in configuration examples and expanded documentation for path-related settings.

* Added clarification and detail to the release publishing process in `DEVELOPMENT.md`, specifying changelog updates and workflow automation.