### PR TITLE
fix: on change of external extension php settings

### DIFF
--- a/src/fixer.ts
+++ b/src/fixer.ts
@@ -42,7 +42,10 @@ const getSettings = async () => {
  * Load Configuration from editor
  */
 const reloadSettings = async (event: ConfigurationChangeEvent) => {
-  if (!event.affectsConfiguration('phpsab')) {
+  if (
+    !event.affectsConfiguration('phpsab') &&
+    !event.affectsConfiguration('php')
+  ) {
     return;
   }
   settingsCache = await loadSettings();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -170,8 +170,10 @@ const validate = async (
     settings.fixerEnable = false;
   }
 
-  logger.log(msg);
-  window.showWarningMessage(msg, 'OK');
+  if (msg) {
+    logger.log(msg);
+    window.showWarningMessage(msg, 'OK');
+  }
 
   return settings;
 };

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -308,7 +308,10 @@ const setValidatorListener = async (): Promise<void> => {
  * @param event - The configuration change event.
  */
 const onConfigChange = async (event: ConfigurationChangeEvent) => {
-  if (!event.affectsConfiguration('phpsab')) {
+  if (
+    !event.affectsConfiguration('phpsab') &&
+    !event.affectsConfiguration('php')
+  ) {
     return;
   }
   settingsCache = await loadSettings();


### PR DESCRIPTION
This pull request updates how configuration changes are detected and handled in the extension, ensuring that changes to the external extension `php` settings trigger a reload of the settings within the extension. This allows the PHP version to be auto-updated when changes to `php.executablePath` and `php.validate.executablePath` settings occur.

Configuration change detection:

* Updated both `reloadSettings` function in `src/fixer.ts` and `onConfigChange` function in `src/sniffer.ts` to reload settings when `php` configurations change, not just `phpsab`.

Settings validation and user feedback:

* Improved the `validate` function in `src/settings.ts` to ensure that warning messages are logged and shown to the user only when a message exists, preventing empty logs in the output channel.