### PR TITLE
ci: version bump actions

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -21,7 +21,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       is-valid: ${{ steps.parse-version.outputs.is-valid }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: "npm"
@@ -83,7 +83,7 @@ jobs:
     if: needs.validate-and-build.outputs.is-valid == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: "npm"
@@ -116,7 +116,7 @@ jobs:
           fi
 
       - name: Get Release Notes and Update Changelog
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const updateChangelog = await import('${{ github.workspace }}/.github/scripts/update-changelog.mjs');
@@ -165,13 +165,13 @@ jobs:
     if: github.event_name == 'release' && github.event.release.prerelease == false
     steps:
       - name: Checkout Updated Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TARGET_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: "npm"
@@ -180,12 +180,12 @@ jobs:
         run: npm ci
 
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
@@ -201,10 +201,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
           cache: "npm"
@@ -225,7 +225,7 @@ jobs:
 
       - name: Publish to Open VSX Registry
         if: ${{ inputs.skip_open_vsx != true }}
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
 
@@ -234,7 +234,7 @@ jobs:
         run: echo "⏭️  Skipping Open VSX publish (skip_open_vsx input is true)"
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
 
       - name: Install Dependencies
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
 
       - name: Install Dependencies
@@ -173,7 +173,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
 
       - name: Install Dependencies
@@ -206,7 +206,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 


### PR DESCRIPTION
This pull request version bumps all 3rd party actions to use the latest versions and update Node version to 22.x in all workflows.

**Version bumps**

Copilot reported these important breaking changes:

- [`checkout@v7`](https://github.com/actions/checkout/tree/v7) refuses to check out fork pull request code by default for `pull_request_target` and `workflow_run`. 
  This workflow checks out the base repository, so no change should be needed.

- [`setup-node@v7`](https://github.com/actions/setup-node/tree/v7/) uses Node 24 internally and requires a sufficiently recent runner. 
  GitHub-hosted runners satisfy this.

- [`github-script@v9`](https://github.com/actions/github-script/tree/v9/) removes `require('@actions/github');`.
 The workflow scripts already directly uses `github` context instead, so it is compatible.

- [`publish-vscode-extension@v2`](https://github.com/HaaLeo/publish-vscode-extension/tree/v2/) upgrades `vsce` and `ovsx`; the existing inputs remain compatible.
  **You may need to test an actual marketplace publish because packaging behaviour can change.**
  
So an actual publish to the marketplaces is needed to ensure it works. (No point doing a publish without a change to the code though.) **Edit: Publishing to the marketplaces still works.**

**Node Version**

- Updated the `node-version` to use `22.x` so that it better matches the current `@types/node` dependency of 22 to minimise any possible runtime compatibility issues.